### PR TITLE
Module fixes after testing with the `0.23` TF provider

### DIFF
--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -29,8 +29,10 @@ module "lacework_aws_agentless_scanning_regional" {
     aws = aws.usw2
   }
 
-  agentless_scan_ecs_task_role_arn = module.lacework_agentless_global.agentless_scan_ecs_task_role_arn
+  agentless_scan_ecs_task_role_arn      = module.lacework_agentless_global.agentless_scan_ecs_task_role_arn
   agentless_scan_ecs_execution_role_arn = module.lacework_agentless_global.agentless_scan_ecs_execution_role_arn
-  agentless_scan_ecs_event_role_arn = module.lacework_agentless_global.agentless_scan_ecs_event_role_arn
+  agentless_scan_ecs_event_role_arn     = module.lacework_agentless_global.agentless_scan_ecs_event_role_arn
+  agentless_scan_secret_arn             = module.lacework_aws_agentless_scanning_global.agentless_scan_secret_arn
+  lacework_account                      = module.lacework_aws_agentless_scanning_global.lacework_account
 }
 ```

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -14,6 +14,7 @@ module "lacework_aws_agentless_scanning_global" {
   source = "../.."
 
   global                    = true
+  lacework_account          = "yourlacework"
   lacework_integration_name = "sidekick_from_terraform"
 }
 
@@ -28,4 +29,6 @@ module "lacework_aws_agentless_scanning_region_us_west" {
   agentless_scan_ecs_task_role_arn      = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_task_role_arn
   agentless_scan_ecs_execution_role_arn = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_execution_role_arn
   agentless_scan_ecs_event_role_arn     = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_event_role_arn
+  agentless_scan_secret_arn             = module.lacework_aws_agentless_scanning_global.agentless_scan_secret_arn
+  lacework_account                      = module.lacework_aws_agentless_scanning_global.lacework_account
 }

--- a/main.tf
+++ b/main.tf
@@ -657,6 +657,11 @@ resource "aws_cloudwatch_log_group" "agentless_scan_log_group" {
 
 // AgentlessScanOrchestrateEvent
 resource "aws_cloudwatch_event_rule" "agentless_scan_event_rule" {
+  depends_on = [
+    aws_ecs_cluster.agentless_scan_ecs_cluster,
+    aws_ecs_task_definition.agentless_scan_task_definition
+  ]
+
   count               = var.regional ? 1 : 0
   name                = "${var.resource_name_prefix}-periodic-trigger-${local.resource_name_suffix}"
   schedule_expression = "rate(1 hour)"

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,7 @@ locals {
   agentless_scan_ecs_task_role_arn      = var.global ? aws_iam_role.agentless_scan_ecs_task_role[0].arn : var.agentless_scan_ecs_task_role_arn
   agentless_scan_ecs_execution_role_arn = var.global ? aws_iam_role.agentless_scan_ecs_execution_role[0].arn : var.agentless_scan_ecs_execution_role_arn
   agentless_scan_ecs_event_role_arn     = var.global ? aws_iam_role.agentless_scan_ecs_event_role[0].arn : var.agentless_scan_ecs_event_role_arn
+  agentless_scan_secret_arn             = var.global ? aws_secretsmanager_secret.agentless_scan_secret[0].id : var.agentless_scan_secret_arn
 }
 
 data "aws_region" "current" {}
@@ -44,7 +45,7 @@ resource "aws_secretsmanager_secret_version" "agentless_scan_secret_version" {
   secret_id     = aws_secretsmanager_secret.agentless_scan_secret[0].id
   secret_string = <<EOF
    {
-    "account": "${var.lacework_aws_account_id}",
+    "account": "${var.lacework_account}",
     "token": "${lacework_integration_aws_agentless_scanning.lacework_cloud_account[0].server_token}"
    }
 EOF
@@ -614,11 +615,11 @@ resource "aws_ecs_task_definition" "agentless_scan_task_definition" {
         },
         {
           name  = "LACEWORK_APISERVER"
-          value = "${var.lacework_aws_account_id}"
+          value = "${var.lacework_account}.${var.lacework_domain}"
         },
         {
           name  = "SECRET_ARN"
-          value = "${var.resource_name_prefix}-bucket-${local.resource_name_suffix}"
+          value = "${local.agentless_scan_secret_arn}"
         },
         {
           name  = "LOCAL_STORAGE"

--- a/main.tf
+++ b/main.tf
@@ -282,7 +282,7 @@ resource "aws_iam_role" "agentless_scan_ecs_event_role" {
 // AWS::IAM::Role
 resource "aws_iam_role" "agentless_scan_ecs_execution_role" {
   count                = var.global ? 1 : 0
-  name                 = "${var.resource_name_prefix}-task-execution-role-${local.resource_name_suffix}"
+  name                 = "${var.resource_name_prefix}-task-exec-role-${local.resource_name_suffix}"
   max_session_duration = 3600
   path                 = "/"
   managed_policy_arns  = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]

--- a/output.tf
+++ b/output.tf
@@ -12,3 +12,13 @@ output "agentless_scan_ecs_event_role_arn" {
   value       = local.agentless_scan_ecs_event_role_arn
   description = "Output ecs event role arn"
 }
+
+output "agentless_scan_secret_arn" {
+  value       = local.agentless_scan_secret_arn
+  description = "AWS SecretsManager Secret ARN for Lacework Account and Token"
+}
+
+output "lacework_account" {
+  value       = var.lacework_account
+  description = "Lacework Account Name for Integration"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,17 @@ variable "scan_host_vulnerabilities" {
   default     = true
 }
 
+variable "lacework_account" {
+  type        = string
+  description = "The name of the Lacework account with which to integrate."
+}
+
+variable "lacework_domain" {
+  type        = string
+  description = "The domain of the Lacework account with with to integrate."
+  default     = "lacework.net"
+}
+
 variable "lacework_aws_account_id" {
   type        = string
   default     = "434813966438"
@@ -85,4 +96,10 @@ variable "agentless_scan_ecs_event_role_arn" {
   type        = string
   default     = ""
   description = "Ecs event role arn. Required input for regional resources"
+}
+
+variable "agentless_scan_secret_arn" {
+  type        = string
+  default     = ""
+  description = "AWS SecretsManager Secret ARN for Lacework Account/Token. *Required if Global is `false` and Regional is `true`*"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,8 @@ terraform {
   required_version = ">= 0.15.0"
 
   required_providers {
+    aws    = "~> 4.0"
+    random = ">= 2.1"
     lacework = {
       source  = "lacework/lacework"
       version = "~> 0.23"


### PR DESCRIPTION
## Summary
Fixed a few issues with the variables that are passed through to the ECS Task Definition, and updated the variables and examples as a result.

Fixed a few ease-of-use issues:
- default name for the task role was hitting a 64 character limit
- added a depends_on for the ECS task to require the cluster and task definition be created
- added specific required providers so that when `aws.<alias>` is passed to the module it doesn't throw warnings

## How did you test this change?
Tested by deploying in us-east-1 and us-west-2 and validated task execution.

## Issue
N/A