### PR TITLE
fix: Update readme and examples with required inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ No modules.
 | <a name="input_lacework_aws_account_id"></a> [lacework\_aws\_account\_id](#input\_lacework\_aws\_account\_id) | The Lacework AWS account that the IAM role will grant access. | `string` | `"434813966438"` | no |
 | <a name="input_lacework_domain"></a> [lacework\_domain](#input\_lacework\_domain) | The Lacework domain name. Defaults to `lacework.net`. | `string` | `"lacework.net"` | no |
 | <a name="input_lacework_integration_name"></a> [lacework\_integration\_name](#input\_lacework\_integration\_name) | The name of the Lacework cloud account integration. | `string` | `"aws-agentless-scan"` | no |
-| <a name="input_regional"></a> [regional](#input\_regional) | Whether or not to create regional resources. Defaults to `true`. | `bool` | `true` | no |
+| <a name="input_regional"></a> [regional](#input\_regional) | Whether or not to create regional resources. Defaults to `false`. | `bool` | `false` | no |
 | <a name="input_resource_name_prefix"></a> [resource\_name\_prefix](#input\_resource\_name\_prefix) | A string to be prefixed to the name of all new resources. | `string` | n/a | yes |
 | <a name="input_resource_name_suffix"></a> [resource\_name\_suffix](#input\_resource\_name\_suffix) | A string to be appended to the end of the name of all new resources. | `string` | n/a | yes |
 | <a name="input_scan_containers"></a> [scan\_containers](#input\_scan\_containers) | Whether to includes scanning for containers.  Defaults to `true`. | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -68,14 +68,16 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_agentless_scan_ecs_event_role_arn"></a> [agentless\_scan\_ecs\_event\_role\_arn](#input\_agentless\_scan\_ecs\_event\_role\_arn) | Ecs event role arn. Required input for regional resources | `string` | `""` | no |
-| <a name="input_agentless_scan_ecs_execution_role_arn"></a> [agentless\_scan\_ecs\_execution\_role\_arn](#input\_agentless\_scan\_ecs\_execution\_role\_arn) | Ecs execution role arn. Required input for regional resources | `string` | `""` | no |
-| <a name="input_agentless_scan_ecs_task_role_arn"></a> [agentless\_scan\_ecs\_task\_role\_arn](#input\_agentless\_scan\_ecs\_task\_role\_arn) | Ecs task role arn. Required input for regional resources | `string` | `""` | no |
+| <a name="input_agentless_scan_ecs_event_role_arn"></a> [agentless\_scan\_ecs\_event\_role\_arn](#input\_agentless\_scan\_ecs\_event\_role\_arn) | ECS event role ARN. Required input for regional resources. | `string` | `""` | no |
+| <a name="input_agentless_scan_ecs_execution_role_arn"></a> [agentless\_scan\_ecs\_execution\_role\_arn](#input\_agentless\_scan\_ecs\_execution\_role\_arn) | ECS execution role ARN. Required input for regional resources. | `string` | `""` | no |
+| <a name="input_agentless_scan_ecs_task_role_arn"></a> [agentless\_scan\_ecs\_task\_role\_arn](#input\_agentless\_scan\_ecs\_task\_role\_arn) | ECS task role ARN. Required input for regional resources. | `string` | `""` | no |
 | <a name="input_filter_query_text"></a> [filter\_query\_text](#input\_filter\_query\_text) | The LQL query text. | `string` | `""` | no |
 | <a name="input_global"></a> [global](#input\_global) | Whether or not to create global resources. Defaults to `false`. | `bool` | `false` | no |
 | <a name="input_iam_service_linked_role"></a> [iam\_service\_linked\_role](#input\_iam\_service\_linked\_role) | Whether or not to create aws\_iam\_service\_linked\_role. Defaults to `false`. | `bool` | `false` | no |
 | <a name="input_image_url"></a> [image\_url](#input\_image\_url) | The container image url for Lacework sidekick. | `string` | `"public.ecr.aws/p5r4i7k7/sidekick:latest"` | no |
+| <a name="input_lacework_account"></a> [lacework\_account](#input\_lacework\_account) | Your Lacework account name. | `string` | `"youraccountname"` | yes |
 | <a name="input_lacework_aws_account_id"></a> [lacework\_aws\_account\_id](#input\_lacework\_aws\_account\_id) | The Lacework AWS account that the IAM role will grant access. | `string` | `"434813966438"` | no |
+| <a name="input_lacework_domain"></a> [lacework\_domain](#input\_lacework\_domain) | The Lacework domain name. Defaults to `lacework.net`. | `string` | `"lacework.net"` | no |
 | <a name="input_lacework_integration_name"></a> [lacework\_integration\_name](#input\_lacework\_integration\_name) | The name of the Lacework cloud account integration. | `string` | `"aws-agentless-scan"` | no |
 | <a name="input_regional"></a> [regional](#input\_regional) | Whether or not to create regional resources. Defaults to `true`. | `bool` | `true` | no |
 | <a name="input_resource_name_prefix"></a> [resource\_name\_prefix](#input\_resource\_name\_prefix) | A string to be prefixed to the name of all new resources. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_agentless_scan_ecs_event_role_arn"></a> [agentless\_scan\_ecs\_event\_role\_arn](#output\_agentless\_scan\_ecs\_event\_role\_arn) | Output ecs event role arn |
-| <a name="output_agentless_scan_ecs_execution_role_arn"></a> [agentless\_scan\_ecs\_execution\_role\_arn](#output\_agentless\_scan\_ecs\_execution\_role\_arn) | Output ecs executuin role arn |
-| <a name="output_agentless_scan_ecs_task_role_arn"></a> [agentless\_scan\_ecs\_task\_role\_arn](#output\_agentless\_scan\_ecs\_task\_role\_arn) | Output ecs task role arn |
+| <a name="output_agentless_scan_ecs_event_role_arn"></a> [agentless\_scan\_ecs\_event\_role\_arn](#output\_agentless\_scan\_ecs\_event\_role\_arn) | Output ECS event role ARN. |
+| <a name="output_agentless_scan_ecs_execution_role_arn"></a> [agentless\_scan\_ecs\_execution\_role\_arn](#output\_agentless\_scan\_ecs\_execution\_role\_arn) | Output ECS execution role ARN. |
+| <a name="output_agentless_scan_ecs_task_role_arn"></a> [agentless\_scan\_ecs\_task\_role\_arn](#output\_agentless\_scan\_ecs\_task\_role\_arn) | Output ECS task role ARN. |
+| <a name="output_agentless_scan_secret_arn"></a> [agentless\_scan\_secret\_arn](#output\_agentless\_scan\_secret\_arn) | Output Secret Manager Secret ARN. |
+| <a name="output_lacework_account"></a> [lacework\_account](#output\_lacework\_account) | Output Lacework account name. |
+| <a name="output_lacework_domain"></a> [lacework\_domain](#output\_lacework\_domain) | Output Lacework domain name. |

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -30,6 +30,7 @@ module "lacework_aws_agentless_scanning_regional" {
     aws = aws.usw2
   }
 
+  regional                              = true
   agentless_scan_ecs_task_role_arn      = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_task_role_arn
   agentless_scan_ecs_execution_role_arn = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_execution_role_arn
   agentless_scan_ecs_event_role_arn     = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_event_role_arn

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -13,11 +13,12 @@ provider "aws" {
   region = "us-west-2"
 }
 
-module "lacework_agentless_global" {
+module "lacework_aws_agentless_scanning_global" {
   source  = "lacework/agentless-scanning/aws"
   version = "~> 0.1"
 
   global                    = true
+  lacework_account          = "yourlacework"
   lacework_integration_name = "sidekick_from_terraform"
 }
 
@@ -29,9 +30,9 @@ module "lacework_aws_agentless_scanning_regional" {
     aws = aws.usw2
   }
 
-  agentless_scan_ecs_task_role_arn      = module.lacework_agentless_global.agentless_scan_ecs_task_role_arn
-  agentless_scan_ecs_execution_role_arn = module.lacework_agentless_global.agentless_scan_ecs_execution_role_arn
-  agentless_scan_ecs_event_role_arn     = module.lacework_agentless_global.agentless_scan_ecs_event_role_arn
+  agentless_scan_ecs_task_role_arn      = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_task_role_arn
+  agentless_scan_ecs_execution_role_arn = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_execution_role_arn
+  agentless_scan_ecs_event_role_arn     = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_event_role_arn
   agentless_scan_secret_arn             = module.lacework_aws_agentless_scanning_global.agentless_scan_secret_arn
   lacework_account                      = module.lacework_aws_agentless_scanning_global.lacework_account
 }

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -26,6 +26,7 @@ module "lacework_aws_agentless_scanning_region_us_west" {
     aws = aws.usw2
   }
 
+  regional                              = true
   agentless_scan_ecs_task_role_arn      = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_task_role_arn
   agentless_scan_ecs_execution_role_arn = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_execution_role_arn
   agentless_scan_ecs_event_role_arn     = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_event_role_arn

--- a/examples/global_only/README.md
+++ b/examples/global_only/README.md
@@ -12,6 +12,7 @@ module "lacework_aws_agentless_scanning_global" {
   source                    = "../.."
   global                    = true
   regional                  = false
+  lacework_account          = "yourlacework"
   resource_name_prefix      = "lacework"
   resource_name_suffix      = "terraform"
   lacework_integration_name = "sidekick_from_terraform"

--- a/examples/global_only/main.tf
+++ b/examples/global_only/main.tf
@@ -9,6 +9,7 @@ module "lacework_aws_agentless_scanning_global" {
   source                    = "../.."
   global                    = true
   regional                  = false
+  lacework_account          = "yourlacework"
   resource_name_prefix      = "lacework"
   resource_name_suffix      = "terraform"
   lacework_integration_name = "sidekick_from_terraform"

--- a/output.tf
+++ b/output.tf
@@ -22,3 +22,8 @@ output "lacework_account" {
   value       = var.lacework_account
   description = "Lacework Account Name for Integration"
 }
+
+output "lacework_domain" {
+  value       = var.lacework_domain
+  description = "Lacework Domain Name for Integration"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -70,7 +70,7 @@ variable "global" {
 
 variable "regional" {
   type        = bool
-  default     = true
+  default     = false
   description = "Whether or not to create regional resources. Defaults to `true`."
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

This is a change to the README to document more of the inputs.

The change also updates the example READMEs to correct the inputs (to include `lacework_account`).

Finally, this flips the default for `regional` from `true` to `false`. This feels safer as people have to opt-in to creating the regional resources.

## How did you test this change?

Deployed this module.

## Issue

N/A