### PR TITLE
Add force_destroy to S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ No modules.
 | <a name="input_agentless_scan_ecs_event_role_arn"></a> [agentless\_scan\_ecs\_event\_role\_arn](#input\_agentless\_scan\_ecs\_event\_role\_arn) | ECS event role ARN. Required input for regional resources. | `string` | `""` | no |
 | <a name="input_agentless_scan_ecs_execution_role_arn"></a> [agentless\_scan\_ecs\_execution\_role\_arn](#input\_agentless\_scan\_ecs\_execution\_role\_arn) | ECS execution role ARN. Required input for regional resources. | `string` | `""` | no |
 | <a name="input_agentless_scan_ecs_task_role_arn"></a> [agentless\_scan\_ecs\_task\_role\_arn](#input\_agentless\_scan\_ecs\_task\_role\_arn) | ECS task role ARN. Required input for regional resources. | `string` | `""` | no |
+| <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | Force destroy S3 bucket when removing the module. | `bool` | `true` | no |
 | <a name="input_filter_query_text"></a> [filter\_query\_text](#input\_filter\_query\_text) | The LQL query text. | `string` | `""` | no |
 | <a name="input_global"></a> [global](#input\_global) | Whether or not to create global resources. Defaults to `false`. | `bool` | `false` | no |
 | <a name="input_iam_service_linked_role"></a> [iam\_service\_linked\_role](#input\_iam\_service\_linked\_role) | Whether or not to create aws\_iam\_service\_linked\_role. Defaults to `false`. | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -332,6 +332,8 @@ resource "aws_s3_bucket" "agentless_scan_bucket" {
   count  = var.global ? 1 : 0
   bucket = "${var.resource_name_prefix}-bucket-${local.resource_name_suffix}"
 
+  force_destroy = var.bucket_force_destroy
+
   tags = {
     LWTAG_SIDEKICK = "1"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -103,3 +103,9 @@ variable "agentless_scan_secret_arn" {
   default     = ""
   description = "AWS SecretsManager Secret ARN for Lacework Account/Token. *Required if Global is `false` and Regional is `true`*"
 }
+
+variable "bucket_force_destroy" {
+  type        = bool
+  default     = true
+  description = "Force destroy bucket (Required when bucket not empty)"
+}


### PR DESCRIPTION
Signed-off-by: Teddy Reed <teddy.reed@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

The S3 bucket is used for temporary state. It can be safely removed at anytime.

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

Run the module locally and remove (verify no error on removal).

## Issue

N/A