### PR TITLE
fix: ignore out-of-band updates to ECS cluster tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -586,6 +586,12 @@ resource "aws_ecs_cluster" "agentless_scan_ecs_cluster" {
     Name           = "${var.prefix}-cluster"
     LWTAG_SIDEKICK = "1"
   }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 // TaskDefinition


### PR DESCRIPTION
## Summary
This fix tells the module to ignore changes to the ECS cluster tags.

The sidekick scanner appears to add several tags to the ECS cluster(s) upon execution.  Since Terraform is unaware of those changes, it will try to remove them unless we tell it not to.  The module should be idempotent.

## How did you test this change?
Tested in my organization with a running scanner.

## Issue
N/A