### PR TITLE
fix: Output the suffix and prefix values

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,5 +95,7 @@ No modules.
 | <a name="output_agentless_scan_ecs_execution_role_arn"></a> [agentless\_scan\_ecs\_execution\_role\_arn](#output\_agentless\_scan\_ecs\_execution\_role\_arn) | Output ECS execution role ARN. |
 | <a name="output_agentless_scan_ecs_task_role_arn"></a> [agentless\_scan\_ecs\_task\_role\_arn](#output\_agentless\_scan\_ecs\_task\_role\_arn) | Output ECS task role ARN. |
 | <a name="output_agentless_scan_secret_arn"></a> [agentless\_scan\_secret\_arn](#output\_agentless\_scan\_secret\_arn) | Output Secret Manager Secret ARN. |
+| <a name="output_prefix"></a> [prefix](#output\_prefix) | Output prefix value. |
+| <a name="output_suffix"></a> [suffix](#output\_suffix) | Output suffix value. |
 | <a name="output_lacework_account"></a> [lacework\_account](#output\_lacework\_account) | Output Lacework account name. |
 | <a name="output_lacework_domain"></a> [lacework\_domain](#output\_lacework\_domain) | Output Lacework domain name. |

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -35,6 +35,7 @@ module "lacework_aws_agentless_scanning_regional" {
   agentless_scan_ecs_event_role_arn     = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_event_role_arn
   agentless_scan_secret_arn             = module.lacework_aws_agentless_scanning_global.agentless_scan_secret_arn
   lacework_account                      = module.lacework_aws_agentless_scanning_global.lacework_account
+  suffix                                = module.lacework_aws_agentless_scanning_global.suffix
 }
 ```
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,15 +1,15 @@
 provider "lacework" {}
 
 provider "aws" {
-  region = "eu-west-1"
+  region = "us-west-1"
 }
 
 provider "aws" {
   alias  = "usw2"
-  region = "eu-north-1"
+  region = "us-west-2"
 }
 
-// Create global and regional resources, includes lacework cloud integration
+// Create global resources, includes lacework cloud integration
 module "lacework_aws_agentless_scanning_global" {
   source = "../.."
 
@@ -17,8 +17,22 @@ module "lacework_aws_agentless_scanning_global" {
   lacework_integration_name = "sidekick_from_terraform"
 }
 
-// By default only regional resources are created
-module "lacework_aws_agentless_scanning_region_us_west" {
+// Create regional resources in our first region
+module "lacework_aws_agentless_scanning_region" {
+  source = "../.."
+
+  regional                              = true
+  agentless_scan_ecs_task_role_arn      = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_task_role_arn
+  agentless_scan_ecs_execution_role_arn = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_execution_role_arn
+  agentless_scan_ecs_event_role_arn     = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_event_role_arn
+  agentless_scan_secret_arn             = module.lacework_aws_agentless_scanning_global.agentless_scan_secret_arn
+  lacework_account                      = module.lacework_aws_agentless_scanning_global.lacework_account
+  prefix                                = module.lacework_aws_agentless_scanning_global.prefix
+  suffix                                = module.lacework_aws_agentless_scanning_global.suffix
+}
+
+// Create regional resources in our second region
+module "lacework_aws_agentless_scanning_region_usw2" {
   source = "../.."
 
   providers = {
@@ -31,4 +45,6 @@ module "lacework_aws_agentless_scanning_region_us_west" {
   agentless_scan_ecs_event_role_arn     = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_event_role_arn
   agentless_scan_secret_arn             = module.lacework_aws_agentless_scanning_global.agentless_scan_secret_arn
   lacework_account                      = module.lacework_aws_agentless_scanning_global.lacework_account
+  prefix                                = module.lacework_aws_agentless_scanning_global.prefix
+  suffix                                = module.lacework_aws_agentless_scanning_global.suffix
 }

--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,10 @@ data "aws_iam_policy_document" "agentless_scan_task_policy_document" {
     sid       = "AllowControlOfBucket"
     effect    = "Allow"
     actions   = ["s3:*"]
-    resources = ["${aws_s3_bucket.agentless_scan_bucket[0].arn}", "${aws_s3_bucket.agentless_scan_bucket[0].arn}/*"]
+    resources = [
+      "${aws_s3_bucket.agentless_scan_bucket[0].arn}",
+      "${aws_s3_bucket.agentless_scan_bucket[0].arn}/*"
+    ]
   }
 
   statement {
@@ -565,7 +568,7 @@ resource "aws_subnet" "agentless_scan_public_subnet" {
 
 
   tags = {
-    Name           = "${var.prefix}-subnet"
+    Name           = "${var.prefix}-vpc"
     LWTAG_SIDEKICK = "1"
   }
 }

--- a/output.tf
+++ b/output.tf
@@ -18,6 +18,16 @@ output "agentless_scan_secret_arn" {
   description = "AWS SecretsManager Secret ARN for Lacework Account and Token"
 }
 
+output "prefix" {
+  value       = var.prefix
+  description = "Prefix used to add uniqueness to resource names"
+}
+
+output "suffix" {
+  value       = local.suffix
+  description = "Suffix used to add uniqueness to resource names"
+}
+
 output "lacework_account" {
   value       = var.lacework_account
   description = "Lacework Account Name for Integration"

--- a/variables.tf
+++ b/variables.tf
@@ -8,12 +8,22 @@ variable "prefix" {
   type        = string
   description = "A string to be prefixed to the name of all new resources."
   default     = "lacework-agentless-scanning"
+
+  validation {
+    condition     = length(regexall(".*lacework.*", var.prefix)) > 0
+    error_message = "The prefix value must include the term 'lacework'."
+  }
 }
 
 variable "suffix" {
   type        = string
   description = "A string to be appended to the end of the name of all new resources."
   default     = ""
+
+  validation {
+    condition     = length(var.suffix) == 0 || length(var.suffix) > 4
+    error_message = "If the suffix value is set then it must be at least 4 characters long."
+  }
 }
 
 variable "lacework_integration_name" {
@@ -39,6 +49,7 @@ variable "scan_containers" {
   description = "Whether to includes scanning for containers.  Defaults to `true`."
   default     = true
 }
+
 variable "scan_host_vulnerabilities" {
   type        = bool
   description = "Whether to includes scanning for host vulnerabilities.  Defaults to `true`."


### PR DESCRIPTION
The `suffix` input allows module users to add uniqueness to the resources created. This helps in the rare situations where multiple agentless integrations are installed into the same account and same region.

We should set this value as an output so that folks can use the same suffix in both global and regional deployments.

We also use the prefix as our unique identifier name namespace (then the resource name) for restricting access in IAM conditions. 

## Summary
Output suffix and update example to set the same suffix name in both modules.
