### PR TITLE
docs(examples): Update examples for 0.3.2 usage

### DIFF
--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -5,7 +5,7 @@
 provider "lacework" {}
 
 provider "aws" {
-  region = "us-east-1"
+  region = "us-west-1"
 }
 
 provider "aws" {
@@ -15,15 +15,31 @@ provider "aws" {
 
 module "lacework_aws_agentless_scanning_global" {
   source  = "lacework/agentless-scanning/aws"
-  version = "~> 0.1"
+  version = ">= 0.3.2"
 
   global                    = true
   lacework_integration_name = "sidekick_from_terraform"
 }
 
-module "lacework_aws_agentless_scanning_regional" {
+// Create regional resources in our first region
+module "lacework_aws_agentless_scanning_region" {
   source  = "lacework/agentless-scanning/aws"
-  version = "~> 0.1"
+  version = ">= 0.3.2"
+
+  regional                              = true
+  agentless_scan_ecs_task_role_arn      = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_task_role_arn
+  agentless_scan_ecs_execution_role_arn = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_execution_role_arn
+  agentless_scan_ecs_event_role_arn     = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_event_role_arn
+  agentless_scan_secret_arn             = module.lacework_aws_agentless_scanning_global.agentless_scan_secret_arn
+  lacework_account                      = module.lacework_aws_agentless_scanning_global.lacework_account
+  prefix                                = module.lacework_aws_agentless_scanning_global.prefix
+  suffix                                = module.lacework_aws_agentless_scanning_global.suffix
+}
+
+// Create regional resources in our second region
+module "lacework_aws_agentless_scanning_region_usw2" {
+  source  = "lacework/agentless-scanning/aws"
+  version = ">= 0.3.2"
 
   providers = {
     aws = aws.usw2
@@ -35,6 +51,7 @@ module "lacework_aws_agentless_scanning_regional" {
   agentless_scan_ecs_event_role_arn     = module.lacework_aws_agentless_scanning_global.agentless_scan_ecs_event_role_arn
   agentless_scan_secret_arn             = module.lacework_aws_agentless_scanning_global.agentless_scan_secret_arn
   lacework_account                      = module.lacework_aws_agentless_scanning_global.lacework_account
+  prefix                                = module.lacework_aws_agentless_scanning_global.prefix
   suffix                                = module.lacework_aws_agentless_scanning_global.suffix
 }
 ```

--- a/examples/singleregion/README.md
+++ b/examples/singleregion/README.md
@@ -1,0 +1,27 @@
+# Single Region Example
+
+```hcl
+
+provider "lacework" {}
+
+provider "aws" {
+  region = "us-west-1"
+}
+
+module "lacework_aws_agentless_scanning_singleregion" {
+  source  = "lacework/agentless-scanning/aws"
+  version = ">= 0.3.2"
+
+  global                    = true
+  regional                  = true
+  lacework_integration_name = "sidekick_from_terraform"
+}
+```
+
+In this example the **global** resources and **regional** resources are added.
+Global resources include the single per-account resources like IAM roles,
+policies, and S3 bucket. Regional resources include a VPC, and ECS cluster.
+This example uses a single module to add both types of resources.
+This is the simplest usage but only supports a single account and single region.
+
+Refer to the *default* example for adding scanning to multiple regions.

--- a/examples/singleregion/main.tf
+++ b/examples/singleregion/main.tf
@@ -1,0 +1,16 @@
+provider "lacework" {}
+
+provider "aws" {
+  region = "us-west-1"
+}
+
+// Create global resources, includes lacework cloud integration.
+// This will also create regional resources too.
+// If scanning should occur on multiple regions then refer to the 'default' example.
+module "lacework_aws_agentless_scanning_singleregion" {
+  source = "../.."
+
+  global                    = true
+  regional                  = true
+  lacework_integration_name = "sidekick_from_terraform"
+}

--- a/examples/singleregion/versions.tf
+++ b/examples/singleregion/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.15.0"
+
+  required_providers {
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.25"
+    }
+  }
+}

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -10,6 +10,7 @@ readonly project_name=terraform-aws-agentless-scanning
 
 TEST_CASES=(
   examples/default
+  examples/singleregion
 )
 
 log() {


### PR DESCRIPTION
Heads up that this documentation update is intended to happen after we release 0.3.2 (which happened already, yay!)

## Summary

This updates the examples to add a `>=` requirement for the module to make sure the recent changes are included.

## How did you test this change?

Testing a local deploy using this branch `ref=`.
