### PR TITLE
fix: Update bucket policy to correct object ARN

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -450,7 +450,7 @@ data "aws_iam_policy_document" "cross_account_inline_policy_bucket" {
       "s3:PutObject",
       "s3:GetObject"
     ]
-    resources = [aws_s3_bucket.agentless_scan_bucket[0].arn]
+    resources = ["${aws_s3_bucket.agentless_scan_bucket[0].arn}/*"]
   }
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

This PR fixes the bucket policy to allow PUT, GET on bucket objects. Previously the resource was set to the bucket ARN.

## How did you test this change?

Set the source of the module to the GitHub ref:

```
git::https://github.com/lacework/terraform-aws-agentless-scanning?ref=fix-bucket-policy
```
