### PR TITLE
fix: changed security group configuration to match CloudFormation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -577,9 +577,17 @@ resource "aws_route" "agentless_scan_route" {
   route_table_id         = aws_route_table.agentless_scan_route_table[0].id
 }
 
-resource "aws_security_group" "agentless_scan_vpc_egress" {
-  count = var.regional ? 1 : 0
-  name  = "AgentlessScanVPCEgress"
+resource "aws_default_security_group" "default" {
+  count  = var.regional ? 1 : 0
+  vpc_id = aws_vpc.agentless_scan_vpc[0].id
+
+  ingress {
+    protocol  = -1
+    self      = true
+    from_port = 0
+    to_port   = 0
+  }
+
   egress {
     from_port   = 443
     to_port     = 443


### PR DESCRIPTION
## Summary

This PR adjusts the Security Group configuration within the regional scan resources to work around [this issue](https://github.com/hashicorp/terraform-provider-aws/issues/26666).

This also changes the configuration to use the default security group within the VPC, rather than creating a new one.  This matches the behavior we use in CloudFormation deployments: https://github.com/lacework-dev/sidekick/blob/main/cloudformation/scan-regional.json#L104-L118

## How did you test this change?

Tested changes in my AWS account and verified that configuration matches CloudFormation deployment.

## Issue

N/A