### PR TITLE
feat: Allow VPC CIDR to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 | <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 0.25 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.1 |
 
+## Modules
+
+No modules.
+
 ## Resources
 
 | Name | Type |
@@ -79,7 +83,6 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 | <a name="input_global_module_reference"></a> [global\_module\_reference](#input\_global\_module\_reference) | A reference to the global lacework\_aws\_agentless\_scanning module for this account. | <pre>object({<br>    agentless_scan_ecs_task_role_arn      = string<br>    agentless_scan_ecs_execution_role_arn = string<br>    agentless_scan_ecs_event_role_arn     = string<br>    agentless_scan_secret_arn             = string<br>    lacework_account                      = string<br>    lacework_domain                       = string<br>    prefix                                = string<br>    suffix                                = string<br>  })</pre> | <pre>{<br>  "agentless_scan_ecs_event_role_arn": "",<br>  "agentless_scan_ecs_execution_role_arn": "",<br>  "agentless_scan_ecs_task_role_arn": "",<br>  "agentless_scan_secret_arn": "",<br>  "lacework_account": "",<br>  "lacework_domain": "",<br>  "prefix": "",<br>  "suffix": ""<br>}</pre> | no |
 | <a name="input_iam_service_linked_role"></a> [iam\_service\_linked\_role](#input\_iam\_service\_linked\_role) | Whether or not to create aws\_iam\_service\_linked\_role. Defaults to `false`. | `bool` | `false` | no |
 | <a name="input_image_url"></a> [image\_url](#input\_image\_url) | The container image url for Lacework sidekick. | `string` | `"public.ecr.aws/p5r4i7k7/sidekick:latest"` | no |
-| <a name="input_secretsmanager_kms_key_id"></a> [secretsmanager\_kms\_key\_id](#input\_secretsmanager\_kms\_key\_id) | ARN or Id of the AWS KMS key to be used to encrypt the secret values in the versions stored in this secret. Defaults to `null`. | `string` | | `null` | no |
 | <a name="input_lacework_account"></a> [lacework\_account](#input\_lacework\_account) | The name of the Lacework account with which to integrate. | `string` | `""` | no |
 | <a name="input_lacework_aws_account_id"></a> [lacework\_aws\_account\_id](#input\_lacework\_aws\_account\_id) | The Lacework AWS account that the IAM role will grant access. | `string` | `"434813966438"` | no |
 | <a name="input_lacework_domain"></a> [lacework\_domain](#input\_lacework\_domain) | The domain of the Lacework account with with to integrate. | `string` | `"lacework.net"` | no |
@@ -89,7 +92,9 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 | <a name="input_scan_containers"></a> [scan\_containers](#input\_scan\_containers) | Whether to includes scanning for containers.  Defaults to `true`. | `bool` | `true` | no |
 | <a name="input_scan_frequency_hours"></a> [scan\_frequency\_hours](#input\_scan\_frequency\_hours) | How often in hours the scan will run in hours. Defaults to `24`. | `number` | `24` | no |
 | <a name="input_scan_host_vulnerabilities"></a> [scan\_host\_vulnerabilities](#input\_scan\_host\_vulnerabilities) | Whether to includes scanning for host vulnerabilities.  Defaults to `true`. | `bool` | `true` | no |
+| <a name="input_secretsmanager_kms_key_id"></a> [secretsmanager\_kms\_key\_id](#input\_secretsmanager\_kms\_key\_id) | ARN or Id of the AWS KMS key to be used to encrypt the secret values in the versions stored in this secret. | `string` | `null` | no |
 | <a name="input_suffix"></a> [suffix](#input\_suffix) | A string to be appended to the end of the name of all new resources. | `string` | `""` | no |
+| <a name="input_vpc_cidr_block"></a> [vpc\_cidr\_block](#input\_vpc\_cidr\_block) | VPC CIDR block used by isolate scanning VPC and single subnet. | `string` | `"10.10.32.0/24"` | no |
 
 ## Outputs
 

--- a/examples/singleregion/main.tf
+++ b/examples/singleregion/main.tf
@@ -13,4 +13,6 @@ module "lacework_aws_agentless_scanning_singleregion" {
   global                    = true
   regional                  = true
   lacework_integration_name = "sidekick_from_terraform"
+  // In this example the default VPC CIDR block is customized.
+  vpc_cidr_block            = "10.10.34.0/24"
 }

--- a/main.tf
+++ b/main.tf
@@ -541,7 +541,7 @@ resource "aws_iam_role" "agentless_scan_cross_account_role" {
 
 resource "aws_vpc" "agentless_scan_vpc" {
   count                = var.regional ? 1 : 0
-  cidr_block           = "10.10.0.0/16"
+  cidr_block           = var.vpc_cidr_block
   enable_dns_support   = true
   enable_dns_hostnames = true
   instance_tenancy     = "default"
@@ -609,7 +609,7 @@ resource "aws_default_security_group" "default" {
 resource "aws_subnet" "agentless_scan_public_subnet" {
   count                   = var.regional ? 1 : 0
   vpc_id                  = aws_vpc.agentless_scan_vpc[0].id
-  cidr_block              = "10.10.1.0/24"
+  cidr_block              = var.vpc_cidr_block
   map_public_ip_on_launch = false
 
   tags = {

--- a/variables.tf
+++ b/variables.tf
@@ -104,9 +104,20 @@ variable "iam_service_linked_role" {
 }
 
 variable "secretsmanager_kms_key_id" {
-  type        = string 
+  type        = string
   default     = null
   description = "ARN or Id of the AWS KMS key to be used to encrypt the secret values in the versions stored in this secret."
+}
+
+variable "vpc_cidr_block" {
+  type        = string
+  default     = "10.10.32.0/24"
+  description = "VPC CIDR block used by isolate scanning VPC and single subnet."
+
+  validation {
+    condition     = can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))$", var.vpc_cidr_block))
+    error_message = "The VPC CIDR block must match the regex \"([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))\"."
+  }
 }
 
 // The following inputs are considered deprecated.


### PR DESCRIPTION
This is a quality of life change that allows the caller to set the VPC CIDR range.

## Summary

This can be helpful if VPC peering is ever used or for organization / simplicity purposes if the existing static range overlaps other ranges.

## How did you test this change?

Deploy the module locally with a new VPC range, validate the changes apply and that as scan completes.
