### PR TITLE
fix: Update Lacework provider requirement to 0.27

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     random = ">= 2.1"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.25"
+      version = "~> 0.27"
     }
   }
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

Updates the Lacework provider version requirement, because the `lacework_integration_aws_org_agentless_scanning` resource used in 0.5.0 of the module was added in version 0.27 of the provider.

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

I'm being a little lazy and editing in the browser, was going to wait and see if it passes your CI. :) Happy to test something else locally if need be.

## Issue

<!--
  Include the link to a Jira/Github issue
-->