### PR TITLE
chore: update Lacework provider version to v1

### DIFF
--- a/examples/multi-account-multi-region/versions.tf
+++ b/examples/multi-account-multi-region/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.27"
+      version = "~> 1.0"
     }
   }
 }

--- a/examples/single-account-multi-region/versions.tf
+++ b/examples/single-account-multi-region/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.27"
+      version = "~> 1.0"
     }
   }
 }

--- a/examples/single-account-single-region/versions.tf
+++ b/examples/single-account-single-region/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.27"
+      version = "~> 1.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     random = ">= 2.1"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.27"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
set version of terraform-provider-lacework to 1.0.0

[_Created by Sourcegraph batch change `darren.murray/terraform-provider-updater`._](https://lacework.sourcegraph.com/users/darren.murray/batch-changes/terraform-provider-updater)