### PR TITLE
feat: Add default encryption and public access block to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 | [aws_s3_bucket.agentless_scan_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_lifecycle_configuration.agentless_scan_bucket_lifecyle](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_policy.agentless_scan_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.agentless_scan_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.agentless_scan_bucket_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.versioning_example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_secretsmanager_secret.agentless_scan_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.agentless_scan_secret_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |

--- a/main.tf
+++ b/main.tf
@@ -473,6 +473,27 @@ resource "aws_s3_bucket" "agentless_scan_bucket" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "agentless_scan_bucket_public_access_block" {
+  count  = var.global ? 1 : 0
+  bucket = aws_s3_bucket.agentless_scan_bucket[0].id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "agentless_scan_bucket_encryption" {
+  count  = var.global ? 1 : 0
+  bucket = aws_s3_bucket.agentless_scan_bucket[0].id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "AES256"
+    }
+  }
+}
+
 resource "aws_s3_bucket_versioning" "versioning_example" {
   count  = var.global ? 1 : 0
   bucket = aws_s3_bucket.agentless_scan_bucket[0].id


### PR DESCRIPTION
## Summary

This adds a public access block and AWS-managed server side encryption settings to the S3 bucket.

## How did you test this change?

Apply the settings to an existing bucket and validate end to end.

## Issue

N/A