### PR TITLE
feat: add support for using existing IAM roles and policies

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -202,3 +202,46 @@ variable "suffix" {
     error_message = "If the suffix value is set then it must be at least 4 characters long."
   }
 }
+
+variable "use_existing_cross_account_role" {
+  type        = bool
+  default     = false
+  description = "Set this to true to use an existing IAM cross account role"
+}
+
+variable "use_existing_task_role" {
+  type        = bool
+  default     = false
+  description = "Set this to true to use an existing IAM task role"
+}
+
+variable "use_existing_execution_role" {
+  type        = bool
+  default     = false
+  description = "Set this to true to use an existing IAM execution role"
+}
+
+variable "use_existing_event_role" {
+  type        = bool
+  default     = false
+  description = "Set this to true to use an existing IAM event role"
+}
+
+variable "cross_account_role_arn" {
+  type        = string
+  default     = ""
+  description = "The IAM cross account role ARN is required when setting use_existing_cross_account_role to true"
+}
+
+variable "cross_account_role_name" {
+  type        = string
+  default     = ""
+  description = "The IAM cross account role name. Required to match with cross_account_role_arn if use_existing_cross_account_role is set to true"
+}
+
+variable "external_id" {
+  type        = string
+  default     = ""
+  description = "The external ID configured inside the IAM role used for cross account access"
+}
+


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

Customer requires that IAM roles and policies are created out of band (manually) from Terraform code. They can then be supplied back to the TF code to complete the deployment process.

These code changes make it possible to create the policies and roles ahead of time, and them supply the ARNs to the Terraform code at deployment time. Some assumptions can be made about resource ARNs based on the AWS account being deployed into and the Suffix input.

## How did you test this change?

I deployed using the following steps
1. Created IAM policies manually
2. Created IAM roles manually
3. Supplied IAM roles to the TF code with other inputs

The process was documented in this custom deployment guide for the customer: https://docs.google.com/document/d/1WVdDbIjZocPWIwqGNpfv1AoEGZGn86Yd6uLa4fGDJes/edit#heading=h.rype6bwvii3n

`module "lacework_aws_agentless_scanning_singleregion" {
  source  = "lacework/agentless-scanning/aws"
  version = "~> 0.5"

  global                      = true
  regional                    = true
  use_existing_iam_role       = true
  use_existing_event_role     = true
  use_existing_execution_role = true
  use_existing_task_role      = true

  iam_role_arn                          = "arn:aws:iam::208579789765:role/lacework-iam-role"
  iam_role_external_id                  = "VON8ab7cfd0"
  agentless_scan_ecs_task_role_arn      = "arn:aws:iam::208579789765:role/lacework-ecs-task-role"
  agentless_scan_ecs_execution_role_arn = "arn:aws:iam::208579789765:role/lacework-ecs-execution-role"
  agentless_scan_ecs_event_role_arn     = "arn:aws:iam::208579789765:role/lacework-ecs-event-role"

  suffix                    = "von1234"
  lacework_integration_name = "TF_agentless_scanning"
}
`

## Issue

Zendesk Ticket: https://lacework.zendesk.com/agent/tickets/9714