### PR TITLE
feat: allow use of an existing VPC for deploying regional scan resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 | [aws_s3_bucket_versioning.versioning_example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_secretsmanager_secret.agentless_scan_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.agentless_scan_secret_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_security_group.agentless_scan_sec_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_subnet.agentless_scan_public_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.agentless_scan_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [lacework_integration_aws_agentless_scanning.lacework_cloud_account](https://registry.terraform.io/providers/lacework/lacework/latest/docs/resources/integration_aws_agentless_scanning) | resource |
@@ -68,7 +69,9 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 | [aws_iam_policy_document.agentless_scan_task_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cross_account_inline_policy_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cross_account_inline_policy_ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_internet_gateway.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/internet_gateway) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_vpc.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 | [lacework_user_profile.current](https://registry.terraform.io/providers/lacework/lacework/latest/docs/data-sources/user_profile) | data source |
 
 ## Inputs
@@ -80,6 +83,9 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 | <a name="input_agentless_scan_ecs_task_role_arn"></a> [agentless\_scan\_ecs\_task\_role\_arn](#input\_agentless\_scan\_ecs\_task\_role\_arn) | ECS task role ARN. Required input for regional resources. (Deprecated: use global\_module\_reference) | `string` | `""` | no |
 | <a name="input_agentless_scan_secret_arn"></a> [agentless\_scan\_secret\_arn](#input\_agentless\_scan\_secret\_arn) | AWS SecretsManager Secret ARN for Lacework Account/Token. *Required if Global is `false` and Regional is `true`*. (Deprecated: use global\_module\_reference) | `string` | `""` | no |
 | <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | Force destroy bucket. (Required when bucket not empty) | `bool` | `true` | no |
+| <a name="input_cross_account_role_arn"></a> [cross\_account\_role\_arn](#input\_cross\_account\_role\_arn) | The IAM cross account role ARN is required when setting use\_existing\_cross\_account\_role to true | `string` | `""` | no |
+| <a name="input_cross_account_role_name"></a> [cross\_account\_role\_name](#input\_cross\_account\_role\_name) | The IAM cross account role name. Required to match with cross\_account\_role\_arn if use\_existing\_cross\_account\_role is set to true | `string` | `""` | no |
+| <a name="input_external_id"></a> [external\_id](#input\_external\_id) | The external ID configured inside the IAM role used for cross account access | `string` | `""` | no |
 | <a name="input_filter_query_text"></a> [filter\_query\_text](#input\_filter\_query\_text) | The LQL query text. | `string` | `""` | no |
 | <a name="input_global"></a> [global](#input\_global) | Whether or not to create global resources. Defaults to `false`. | `bool` | `false` | no |
 | <a name="input_global_module_reference"></a> [global\_module\_reference](#input\_global\_module\_reference) | A reference to the global lacework\_aws\_agentless\_scanning module for this account. | <pre>object({<br>    agentless_scan_ecs_task_role_arn      = string<br>    agentless_scan_ecs_execution_role_arn = string<br>    agentless_scan_ecs_event_role_arn     = string<br>    agentless_scan_secret_arn             = string<br>    lacework_account                      = string<br>    lacework_domain                       = string<br>    external_id                           = string<br>    prefix                                = string<br>    suffix                                = string<br>  })</pre> | <pre>{<br>  "agentless_scan_ecs_event_role_arn": "",<br>  "agentless_scan_ecs_execution_role_arn": "",<br>  "agentless_scan_ecs_task_role_arn": "",<br>  "agentless_scan_secret_arn": "",<br>  "external_id": "",<br>  "lacework_account": "",<br>  "lacework_domain": "",<br>  "prefix": "",<br>  "suffix": ""<br>}</pre> | no |
@@ -98,7 +104,13 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 | <a name="input_secretsmanager_kms_key_id"></a> [secretsmanager\_kms\_key\_id](#input\_secretsmanager\_kms\_key\_id) | ARN or Id of the AWS KMS key to be used to encrypt the secret values in the versions stored in this secret. | `string` | `null` | no |
 | <a name="input_snapshot_role"></a> [snapshot\_role](#input\_snapshot\_role) | Whether or not to create an AWS Organization snapshot role. Defaults to `false`. | `bool` | `false` | no |
 | <a name="input_suffix"></a> [suffix](#input\_suffix) | A string to be appended to the end of the name of all new resources. | `string` | `""` | no |
-| <a name="input_vpc_cidr_block"></a> [vpc\_cidr\_block](#input\_vpc\_cidr\_block) | VPC CIDR block used by isolate scanning VPC and single subnet. | `string` | `"10.10.32.0/24"` | no |
+| <a name="input_use_existing_cross_account_role"></a> [use\_existing\_cross\_account\_role](#input\_use\_existing\_cross\_account\_role) | Set this to true to use an existing IAM cross account role | `bool` | `false` | no |
+| <a name="input_use_existing_event_role"></a> [use\_existing\_event\_role](#input\_use\_existing\_event\_role) | Set this to true to use an existing IAM event role | `bool` | `false` | no |
+| <a name="input_use_existing_execution_role"></a> [use\_existing\_execution\_role](#input\_use\_existing\_execution\_role) | Set this to true to use an existing IAM execution role | `bool` | `false` | no |
+| <a name="input_use_existing_task_role"></a> [use\_existing\_task\_role](#input\_use\_existing\_task\_role) | Set this to true to use an existing IAM task role | `bool` | `false` | no |
+| <a name="input_use_existing_vpc"></a> [use\_existing\_vpc](#input\_use\_existing\_vpc) | Set this to true to use an existing VPC.  The VPC must have a Internet Gateway attached, and `vpc_cidr_block` will be used to create new subnet to isolate scanning resources. | `bool` | `false` | no |
+| <a name="input_vpc_cidr_block"></a> [vpc\_cidr\_block](#input\_vpc\_cidr\_block) | VPC CIDR block used to isolate scanning VPC and single subnet. | `string` | `"10.10.32.0/24"` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of an existing AWS VPC to use for deploying regional scan resources.  Must have an Internet Gateway attached. | `string` | `""` | no |
 
 ## Outputs
 

--- a/examples/multi-account-multi-region/README.md
+++ b/examples/multi-account-multi-region/README.md
@@ -1,6 +1,7 @@
 # AWS Organizations integration Example
 
 In this example we add Terraform modules to three AWS accounts.
+
 - Scanning account, or Security account, where the scanning infrasturcture is installed.
 - Monitored account where a role used to create snapshots, and access snapshot data, is installed.
 - The AWS Organizations Management account so that accounts and OUs can be enumerated for each scan.
@@ -33,7 +34,7 @@ provider "aws" {
 // Create global resources, includes lacework cloud integration
 module "lacework_aws_agentless_scanning_global" {
   source  = "lacework/agentless-scanning/aws"
-  version = "~> 0.5.0"
+  version = "~> 0.5"
 
   providers = {
     aws = aws.scanning-account-usw1
@@ -55,7 +56,7 @@ module "lacework_aws_agentless_scanning_global" {
 // Create regional resources in our first region
 module "lacework_aws_agentless_scanning_region_usw1" {
   source  = "lacework/agentless-scanning/aws"
-  version = "~> 0.5.0"
+  version = "~> 0.5"
 
   providers = {
     aws = aws.scanning-account-usw1
@@ -68,7 +69,7 @@ module "lacework_aws_agentless_scanning_region_usw1" {
 // Create regional resources in our second region
 module "lacework_aws_agentless_scanning_region_usw2" {
   source  = "lacework/agentless-scanning/aws"
-  version = "~> 0.5.0"
+  version = "~> 0.5"
 
   providers = {
     aws = aws.scanning-account-usw2
@@ -91,7 +92,7 @@ provider "aws" {
 // Create the required role for the monitored account.
 module "lacework_aws_agentless_monitored_scanning_role" {
   source  = "lacework/agentless-scanning/aws"
-  version = "~> 0.5.0"
+  version = "~> 0.5"
 
   providers = {
     aws = aws.monitored-account-usw1
@@ -114,7 +115,7 @@ provider "aws" {
 // Create the required role for the management account.
 module "lacework_aws_agentless_management_scanning_role" {
   source  = "lacework/agentless-scanning/aws"
-  version = "~> 0.5.0"
+  version = "~> 0.5"
 
   providers = {
     aws = aws.management-account-usw1

--- a/examples/single-account-existing-vpc/README.md
+++ b/examples/single-account-existing-vpc/README.md
@@ -1,0 +1,42 @@
+# Single Account with Existing VPC Example
+
+```hcl
+
+provider "lacework" {}
+
+provider "aws" {
+  region = "us-west-1"
+}
+
+resource "aws_vpc" "existing" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  instance_tenancy     = "default"
+}
+
+resource "aws_internet_gateway" "existing" {
+  vpc_id = aws_vpc.existing.id
+}
+
+module "lacework_aws_agentless_scanning_singleregion" {
+  source  = "lacework/agentless-scanning/aws"
+  version = "~> 0.5"
+
+  global                    = true
+  regional                  = true
+  lacework_integration_name = "agentless_from_terraform"
+
+  use_existing_vpc = true
+  vpc_id           = aws_vpc.existing.id
+  vpc_cidr_block   = "10.0.0.0/24" # This should be an unused subnet within the VPC's CIDR Block
+}
+```
+
+In this example the **global** resources and **regional** resources are added.
+Global resources include the single per-account resources like IAM roles,
+policies, and S3 bucket. Regional resources include and ECS cluster.
+This example uses a single module to add both types of resources.
+This is the simplest usage but only supports a single account and single region.
+
+Refer to the _default_ example for adding scanning to multiple regions.

--- a/examples/single-account-existing-vpc/main.tf
+++ b/examples/single-account-existing-vpc/main.tf
@@ -1,0 +1,31 @@
+provider "lacework" {}
+
+provider "aws" {
+  region = "us-west-1"
+}
+
+resource "aws_vpc" "existing" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  instance_tenancy     = "default"
+}
+
+resource "aws_internet_gateway" "existing" {
+  vpc_id = aws_vpc.existing.id
+}
+
+// Create global resources, includes lacework cloud integration.
+// This will also create regional resources too.
+// If scanning should occur on multiple regions then refer to the 'default' example.
+module "lacework_aws_agentless_scanning_singleregion" {
+  source = "../.."
+
+  global                    = true
+  regional                  = true
+  lacework_integration_name = "agentless_from_terraform"
+
+  use_existing_vpc = true
+  vpc_id           = aws_vpc.existing.id
+  vpc_cidr_block   = "10.0.0.0/24" # This should be an unused subnet within the VPC's CIDR Block
+}

--- a/examples/single-account-existing-vpc/versions.tf
+++ b/examples/single-account-existing-vpc/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.15.0"
+
+  required_providers {
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 1.0"
+    }
+  }
+}

--- a/examples/single-account-multi-region/README.md
+++ b/examples/single-account-multi-region/README.md
@@ -15,7 +15,7 @@ provider "aws" {
 
 module "lacework_aws_agentless_scanning_global" {
   source  = "lacework/agentless-scanning/aws"
-  version = "~> 0.5.0"
+  version = "~> 0.5"
 
   global                    = true
   lacework_integration_name = "agentless_from_terraform"
@@ -24,7 +24,7 @@ module "lacework_aws_agentless_scanning_global" {
 // Create regional resources in our first region
 module "lacework_aws_agentless_scanning_region" {
   source  = "lacework/agentless-scanning/aws"
-  version = "~> 0.5.0"
+  version = "~> 0.5"
 
   regional                = true
   global_module_reference = module.lacework_aws_agentless_scanning_global
@@ -33,7 +33,7 @@ module "lacework_aws_agentless_scanning_region" {
 // Create regional resources in our second region
 module "lacework_aws_agentless_scanning_region_usw2" {
   source  = "lacework/agentless-scanning/aws"
-  version = "~> 0.5.0"
+  version = "~> 0.5"
 
   providers = {
     aws = aws.usw2

--- a/examples/single-account-single-region/README.md
+++ b/examples/single-account-single-region/README.md
@@ -10,7 +10,7 @@ provider "aws" {
 
 module "lacework_aws_agentless_scanning_singleregion" {
   source  = "lacework/agentless-scanning/aws"
-  version = "~> 0.5.0"
+  version = "~> 0.5"
 
   global                    = true
   regional                  = true
@@ -24,4 +24,4 @@ policies, and S3 bucket. Regional resources include a VPC, and ECS cluster.
 This example uses a single module to add both types of resources.
 This is the simplest usage but only supports a single account and single region.
 
-Refer to the *default* example for adding scanning to multiple regions.
+Refer to the _default_ example for adding scanning to multiple regions.

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -10,6 +10,7 @@ readonly project_name=terraform-aws-agentless-scanning
 
 TEST_CASES=(
   examples/multi-account-multi-region
+  examples/single-account-existing-vpc
   examples/single-account-multi-region
   examples/single-account-single-region
 )

--- a/variables.tf
+++ b/variables.tf
@@ -117,15 +117,27 @@ variable "secretsmanager_kms_key_id" {
   description = "ARN or Id of the AWS KMS key to be used to encrypt the secret values in the versions stored in this secret."
 }
 
+variable "vpc_id" {
+  type        = string
+  default     = ""
+  description = "The ID of an existing AWS VPC to use for deploying regional scan resources.  Must have an Internet Gateway attached."
+}
+
 variable "vpc_cidr_block" {
   type        = string
   default     = "10.10.32.0/24"
-  description = "VPC CIDR block used by isolate scanning VPC and single subnet."
+  description = "VPC CIDR block used to isolate scanning VPC and single subnet."
 
   validation {
     condition     = can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))$", var.vpc_cidr_block))
     error_message = "The VPC CIDR block must match the regex \"([0-9]{1,3}\\.){3}[0-9]{1,3}(\\/([0-9]|[1-2][0-9]|3[0-2]))\"."
   }
+}
+
+variable "use_existing_vpc" {
+  type        = bool
+  default     = false
+  description = "Set this to true to use an existing VPC.  The VPC must have a Internet Gateway attached, and `vpc_cidr_block` will be used to create new subnet to isolate scanning resources."
 }
 
 // The following inputs are use for organization (or multi-account) scanning.


### PR DESCRIPTION
## Summary

This PR is meant to allow users to provide an existing VPC in which to deploy scanner resources.  The existing VPC *must* already have an Internet Gateway attached - I didn't want to automatically create/attach one to prevent any unintended resource exposure.

## How did you test this change?

Tested in a single-account lab environment.

## Issue

N/A