### PR TITLE
fix: Add AWS recommended statements to enforce bucket SSE

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -578,6 +578,48 @@ data "aws_iam_policy_document" "agentless_scan_bucket_policy" {
       values   = ["false"]
     }
   }
+
+  statement {
+    sid    = "ForceSSEOnlyUploads"
+    effect = "Deny"
+    actions = [
+      "s3:PutObject"
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    resources = [
+      "${aws_s3_bucket.agentless_scan_bucket[0].arn}/*"
+    ]
+    condition {
+      test     = "Null"
+      variable = "s3:x-amz-server-side-encryption"
+      values   = ["true"]
+    }
+  }
+
+  # To make this more restrictive, we could force the types of SSE.
+  # Without this, we still Deny when SSE is Null (see above statement).
+  # statement {
+  #   sid    = "ForceSSEAES256OnlyUploads"
+  #   effect = "Deny"
+  #   actions = [
+  #     "s3:PutObject"
+  #   ]
+  #   principals {
+  #     type        = "AWS"
+  #     identifiers = ["*"]
+  #   }
+  #   resources = [
+  #     "${aws_s3_bucket.agentless_scan_bucket[0].arn}/*"
+  #   ]
+  #   condition {
+  #     test     = "StringNotEquals"
+  #     variable = "s3:x-amz-server-side-encryption"
+  #     values   = ["AES256"]
+  #   }
+  # }
 }
 
 data "aws_iam_policy_document" "agentless_scan_cross_account_policy" {


### PR DESCRIPTION
## Summary
AWS is enabling SSE (server side encryption) for data at rest starting this month: https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html

This means we can enhance our bucket policies by forcing SSE to be used at the bucket and object level. This changes so that all of our PutObject requests are required to use SSE. This has been tested on a bucket with SSE enabled and without, in both cases the object results in SSE.

## How did you test this change?
Use the new PR ref on a local module and run the scanner end to end.

## Issue
RAIN-46878