### PR TITLE
feat: remove use the default security group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ locals {
 
   // Existing VPC abstraction
   internet_gateway_id = var.regional ? (var.use_existing_vpc ? data.aws_internet_gateway.selected[0].id : aws_internet_gateway.agentless_scan_gateway[0].id) : ""
-  security_group_id   = var.regional ? (var.use_existing_vpc ? aws_security_group.agentless_scan_sec_group[0].id : aws_default_security_group.default[0].id) : ""
+  security_group_id   = var.regional ? aws_security_group.agentless_scan_sec_group[0].id : ""
   vpc_id              = var.regional ? (var.use_existing_vpc ? data.aws_vpc.selected[0].id : aws_vpc.agentless_scan_vpc[0].id) : ""
 }
 
@@ -792,23 +792,12 @@ resource "aws_default_security_group" "default" {
   count  = var.regional && !var.use_existing_vpc ? 1 : 0
   vpc_id = local.vpc_id
 
-  ingress {
-    protocol  = -1
-    self      = true
-    from_port = 0
-    to_port   = 0
-  }
-
-  egress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  ingress = []
+  egress  = []
 }
 
 resource "aws_security_group" "agentless_scan_sec_group" {
-  count       = var.regional && var.use_existing_vpc ? 1 : 0
+  count       = var.regional ? 1 : 0
   name        = "${local.prefix}-security-group"
   description = "A security group to allow Lacework Agentless Workload Scanning communication."
   vpc_id      = local.vpc_id


### PR DESCRIPTION
## Summary

This PR aims to do two things:
- When we create a VPC, we will remove the standard ingress/egress rules for the `default` security group. (CIS 5.3 for AWS recommends this)
- As a result of the above, we will **always** use a second security group customized for AWLS network traffic.

## How did you test this change?

Deployed to my environment and validated rules.

![lacework-agentless-scanning-security-group-egress](https://user-images.githubusercontent.com/65611624/215828792-0b78b6e3-3e5a-4b49-a8fe-d72734ed8661.png)
![lacework-agentless-scanning-security-group-ingress](https://user-images.githubusercontent.com/65611624/215828794-b17f47f5-3f52-471b-adfa-e567d2e989df.png)
![default-egress](https://user-images.githubusercontent.com/65611624/215828799-8ea8c9ec-a556-4ace-90de-00e604df07c9.png)
![default-ingress](https://user-images.githubusercontent.com/65611624/215828800-5ac21389-ca23-4f36-91ca-dd88f62d9075.png)

## Issue

https://lacework.atlassian.net/browse/RAIN-43602