### PR TITLE
Fix: Add condition to only list secrets with LWTAG_SIDEKICK resource tag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -180,6 +180,11 @@ data "aws_iam_policy_document" "agentless_scan_task_policy_document" {
     effect    = "Allow"
     actions   = ["secretsmanager:ListSecrets"]
     resources = ["*"]
+    condition {
+      test     = "StringLike"
+      variable = "aws:ResourceTag/LWTAG_SIDEKICK"
+      values   = ["*"]
+    }
   }
 
   statement {


### PR DESCRIPTION
## Summary

Currently we allow permissions to ListSecrets for all resources. We want to box that in a little bit more to only ListSecrets that have the sidekick tag applied. Confirmed that the correct condition was added to the permissions as well.

![Screen Shot 2023-02-01 at 9 41 36 AM](https://user-images.githubusercontent.com/107059599/216122783-c6efd258-3a29-4c96-ba05-c8f2b4c20321.png)


More info in this thread: https://lacework.slack.com/archives/C03H3863SQG/p1675184838895419?thread_ts=1675113900.980539&cid=C03H3863SQG

## How did you test this change?

I testing this by deploying an integration using this change locally and running the scanner. All succeeded with no errors.

## Issue

https://lacework.atlassian.net/browse/RAIN-48300