### PR TITLE
fix: Remove AllowListSecrets Permissions from scan task policy 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -175,18 +175,6 @@ data "aws_iam_policy_document" "agentless_scan_task_policy_document" {
     resources = ["${aws_secretsmanager_secret.agentless_scan_secret[0].arn}"]
   }
 
-  # statement {
-  #   sid       = "AllowListSecrets"
-  #   effect    = "Allow"
-  #   actions   = ["secretsmanager:ListSecrets"]
-  #   resources = ["*"]
-  #   condition {
-  #     test     = "StringLike"
-  #     variable = "aws:ResourceTag/LWTAG_SIDEKICK"
-  #     values   = ["*"]
-  #   }
-  # }
-
   statement {
     sid       = "DescribeInstances"
     effect    = "Allow"

--- a/main.tf
+++ b/main.tf
@@ -175,17 +175,17 @@ data "aws_iam_policy_document" "agentless_scan_task_policy_document" {
     resources = ["${aws_secretsmanager_secret.agentless_scan_secret[0].arn}"]
   }
 
-  statement {
-    sid       = "AllowListSecrets"
-    effect    = "Allow"
-    actions   = ["secretsmanager:ListSecrets"]
-    resources = ["*"]
-    condition {
-      test     = "StringLike"
-      variable = "aws:ResourceTag/LWTAG_SIDEKICK"
-      values   = ["*"]
-    }
-  }
+  # statement {
+  #   sid       = "AllowListSecrets"
+  #   effect    = "Allow"
+  #   actions   = ["secretsmanager:ListSecrets"]
+  #   resources = ["*"]
+  #   condition {
+  #     test     = "StringLike"
+  #     variable = "aws:ResourceTag/LWTAG_SIDEKICK"
+  #     values   = ["*"]
+  #   }
+  # }
 
   statement {
     sid       = "DescribeInstances"


### PR DESCRIPTION
## Summary

This is related to [PR #54](https://github.com/lacework/terraform-aws-agentless-scanning/pull/54). We discovered that we no longer use ListSecrets in sidekick and therefore can delete these obsolete permissions. 

## How did you test this change?

Tested via launching a new integration with the changes and running the scanner. Everything worked as expected.
