### PR TITLE
feat: Allow S3 SSE to be disabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -499,12 +499,12 @@ resource "aws_s3_bucket_public_access_block" "agentless_scan_bucket_public_acces
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "agentless_scan_bucket_encryption" {
-  count  = var.global ? 1 : 0
+  count  = var.global && var.bucket_encryption_enabled ? 1 : 0
   bucket = aws_s3_bucket.agentless_scan_bucket[0].id
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm = var.bucket_sse_algorithm
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -96,6 +96,18 @@ variable "bucket_force_destroy" {
   description = "Force destroy bucket. (Required when bucket not empty)"
 }
 
+variable "bucket_encryption_enabled" {
+  type        = bool
+  default     = true
+  description = "Set this to `false` to disable setting S3 SSE."
+}
+
+variable "bucket_sse_algorithm" {
+  type        = string
+  default     = "AES256"
+  description = "The encryption algorithm to use for S3 bucket server-side encryption."
+}
+
 variable "lacework_account" {
   type        = string
   description = "The name of the Lacework account with which to integrate."


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

This allows for the calling module to disable S3 SSE configuration. This might be needed if something else is managing SSE configuration and disabling any attempt to reconfigure SSE.

## How did you test this change?

This was tested by updating local modules to use this branch and set this flag `bucket_encryption_enabled` to false.

## Issue

N/A