### PR TITLE
feat: Allow the user to pass additional custom environment variables …

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -290,3 +290,11 @@ variable "external_id" {
   description = "The external ID configured inside the IAM role used for cross account access"
 }
 
+variable "additional_environment_variables" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default     = []
+  description = "Optional list of additional environment variables passed to the ECS task."
+}


### PR DESCRIPTION
…to the ECS task

In addition the the environment variables which are defined by the module already, the user can add additional environment variables.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
In our setup we don't have an internet gateway. The whole communication is done via transit gateway, direct connect and an on-prem proxy. So we would like to be able to set additional environment variables.

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

I created a minimal setup to test this:

```hcl
terraform {
  required_providers {
  }
}


locals {
  initial = [
    {
      name  = "STARTUP_PROVIDER"
      value = "AWS"
    },
    {
      name  = "STARTUP_RUNMODE"
      value = "TASK"
    },
    {
      name  = "LOCAL_STORAGE"
      value = "/tmp"
    },
    {
      name  = "STARTUP_SERVICE"
      value = "ORCHESTRATE"
    },
  ]

  merged = setunion(local.initial, var.custom)
}

variable "custom" {
  type = list(object({
    name = string
    value = string
  }))

  default = [
    {
      name = "HTTP_PROXY"
      value = "127.0.0.1"
    }
  ]
}

output "output" {
  value = local.merged
}
```
## Issue

<!--
  Include the link to a Jira/Github issue
-->