### PR TITLE
fix: Set ECS_CLUSTER_ARN within task_definition resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_environment_variables"></a> [additional\_environment\_variables](#input\_additional\_environment\_variables) | Optional list of additional environment variables passed to the ECS task. | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
 | <a name="input_agentless_scan_ecs_event_role_arn"></a> [agentless\_scan\_ecs\_event\_role\_arn](#input\_agentless\_scan\_ecs\_event\_role\_arn) | ECS event role ARN. Required input for regional resources. (Deprecated: use global\_module\_reference) | `string` | `""` | no |
 | <a name="input_agentless_scan_ecs_execution_role_arn"></a> [agentless\_scan\_ecs\_execution\_role\_arn](#input\_agentless\_scan\_ecs\_execution\_role\_arn) | ECS execution role ARN. Required input for regional resources. (Deprecated: use global\_module\_reference) | `string` | `""` | no |
 | <a name="input_agentless_scan_ecs_task_role_arn"></a> [agentless\_scan\_ecs\_task\_role\_arn](#input\_agentless\_scan\_ecs\_task\_role\_arn) | ECS task role ARN. Required input for regional resources. (Deprecated: use global\_module\_reference) | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -28,10 +28,6 @@ locals {
       value = "TASK"
     },
     {
-      name  = "ECS_CLUSTER_ARN"
-      value = aws_ecs_cluster.agentless_scan_ecs_cluster[0].arn
-    },
-    {
       name  = "ECS_SUBNET_ID"
       value = local.subnet_id
     },
@@ -910,7 +906,16 @@ resource "aws_ecs_task_definition" "agentless_scan_task_definition" {
       name      = "sidekick"
       image     = var.image_url
       essential = true
-      environment = setunion(local.default_ecs_task_environment_variables, var.additional_environment_variables)
+      environment = setunion(
+        local.default_ecs_task_environment_variables,
+        var.additional_environment_variables,
+        [
+          {
+            name  = "ECS_CLUSTER_ARN"
+            value = aws_ecs_cluster.agentless_scan_ecs_cluster[0].arn
+          },
+        ]
+      )
       linuxParameters = {
         capabilities = {
           Add = ["SYS_PTRACE"]


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

This fixes a bug detected by CI where the ECS cluster is referenced in locals where the resource may not be present:

```
Error: Invalid index

on ../../main.tf line 32, in locals:
32:       value = aws_ecs_cluster.agentless_scan_ecs_cluster[0].arn

aws_ecs_cluster.agentless_scan_ecs_cluster is empty tuple

The given key does not identify an element in this collection value.
```

## How did you test this change?

Run CI tests again.

## Issue

N/A