### PR TITLE
fix: Ensure security group is passed to scan task via environment variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,10 @@ locals {
       value = local.subnet_id
     },
     {
+      name  = "ECS_SECURITY_GROUP_ID"
+      value = "${local.security_group_id}"
+    },
+    {
       name  = "S3_BUCKET"
       value = "${local.prefix}-bucket-${local.suffix}"
     },


### PR DESCRIPTION
## Summary
This fixes a bug introduced in [!52](https://github.com/lacework/terraform-aws-agentless-scanning/pull/52) to enforce that all traffic from our scanning cluster passes through our custom security group instead of the default one. For this to work, the custom security group needs to be passed as input to the scan task. 

We've made a change in the scanner to receive this security group via environment variable; this PR introduces a matching change to ensure this environment variable is set when deploying with Terraform.

## How did you test this change?
Deployed a Terraform org integration in-house to reproduce the issue, and then re-deployed with this fix in place and verified that the scanning task now succeeds.

## Issue
N/A