### PR TITLE
fix: Add kms:ViaService condition to KMS policy statements

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -282,6 +282,11 @@ data "aws_iam_policy_document" "agentless_scan_task_policy_document" {
       "kms:CreateGrant"
     ]
     resources = ["*"]
+    condition {
+      test     = "StringLike"
+      variable = "kms:ViaService"
+      values   = ["ec2.*.amazonaws.com"]
+    }
   }
 
   statement {
@@ -478,23 +483,22 @@ resource "aws_iam_role" "agentless_scan_snapshot_role" {
           }
         },
         {
-          Sid = "SnapshotEncryption"
+          Sid    = "SnapshotEncryption"
+          Effect = "Allow"
           Action = [
-            "kms:Decrypt",
+            "kms:DescribeKey",
             "kms:Encrypt",
+            "kms:Decrypt",
             "kms:ReEncrypt*",
-            "kms:CreateGrant",
             "kms:GenerateDataKey*",
-            "kms:PutKeyPolicy"
+            "kms:CreateGrant"
           ]
-          Effect   = "Allow"
           Resource = "*"
-        },
-        {
-          Sid      = "SnapshotKms"
-          Action   = ["kms:Describe*", "kms:List*", "kms:Get*"]
-          Effect   = "Allow"
-          Resource = "*"
+          Condition = {
+            StringLike = {
+              "kms:ViaService" = "ec2.*.amazonaws.com"
+            }
+          }
         },
         {
           Sid      = "OrgPermissions"


### PR DESCRIPTION
## Summary

This adds restrictions to how the Lacework agentless scanner uses KMS keys. The scanner always runs in a user's cloud and does not provide any access outside of the organization to KMS keys. However, the scanner does not access KMS directly, but rather needs KMS access on behalf of EC2 and EBS. These keys are used indirectly when GetSnapshotBlock APIs are used on snapshots with encrypted blocks.

## How did you test this change?

Several scenarios were tested where:
- The default AWS KMS key was used to encrypt a volume.
- A customer-managed key was used to encrypt a volume.
- The scanner was installed in a dedicated scanning account and monitoring other accounts in the organization.

## Issue

N/A, this is a proactive hardening fixup.