### PR TITLE
feat: Allow usage of internet gateway to be optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ locals {
   cross_account_role_name               = length(var.cross_account_role_name) > 0 ? var.cross_account_role_name : "${local.prefix}-cross-account-role-${local.suffix}"
 
   // Existing VPC abstraction
-  internet_gateway_id = var.regional ? (var.use_existing_vpc ? data.aws_internet_gateway.selected[0].id : aws_internet_gateway.agentless_scan_gateway[0].id) : ""
+  internet_gateway_id = var.regional && var.use_internet_gateway ? (var.use_existing_vpc ? data.aws_internet_gateway.selected[0].id : aws_internet_gateway.agentless_scan_gateway[0].id) : ""
   security_group_id   = var.regional ? (var.use_existing_security_group ? var.security_group_id : aws_security_group.agentless_scan_sec_group[0].id) : ""
   subnet_id           = var.regional ? (var.use_existing_subnet ? var.subnet_id : aws_subnet.agentless_scan_public_subnet[0].id) : ""
   vpc_id              = var.regional ? (var.use_existing_vpc ? data.aws_vpc.selected[0].id : aws_vpc.agentless_scan_vpc[0].id) : ""
@@ -68,7 +68,7 @@ data "aws_vpc" "selected" {
 }
 
 data "aws_internet_gateway" "selected" {
-  count = var.regional && var.use_existing_vpc ? 1 : 0
+  count = var.regional && var.use_existing_vpc && var.use_internet_gateway ? 1 : 0
   filter {
     name   = "attachment.vpc-id"
     values = [var.vpc_id]

--- a/variables.tf
+++ b/variables.tf
@@ -316,3 +316,9 @@ variable "additional_environment_variables" {
   default     = []
   description = "Optional list of additional environment variables passed to the ECS task."
 }
+
+variable "use_internet_gateway" {
+  type = bool
+  default = true
+  description = "Whether or not you want to use an 'AWS internet gateway' for internet facing traffic. Only set this to false if you route internet traffic using a different approach."
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
In one of our customers setup we are not using IGWs. The usage is prohibited. The internet facing traffic is completely routed via transit gateway and direct connect to an on-prem firewall/proxy setup. Which means that we cannot deploy the regional setup. That's why I added a new optional variable `use_internet_gateway` having its default value set to `true`. This variable should indicate whether to use an IGW for internet facing traffic or not.

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

We got the following error:
 > │ Error: no matching EC2 Internet Gateway found
│
│   with module.lacework_aws_agentless_scanning_regional.data.aws_internet_gateway.selected[0],

I then used my local fork presented in this PR instead of the release version of the module.
First I changed nothing so that the default of `use_internet_gateway` which is `true` would be used. As expected the same error occured.
When setting `use_internet_gateway` to `false` the error doesn't occur anymore.

## Issue

<!--
  Include the link to a Jira/Github issue
-->