### PR TITLE
fix: s3 bucket ownership controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 | [aws_route_table.agentless_scan_route_table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table_association.agentless_scan_route_table_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_s3_bucket.agentless_scan_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_ownership_controls.agentless_scan_bucket_ownership_controls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_lifecycle_configuration.agentless_scan_bucket_lifecyle](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_policy.agentless_scan_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.agentless_scan_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |

--- a/main.tf
+++ b/main.tf
@@ -531,6 +531,15 @@ resource "aws_s3_bucket" "agentless_scan_bucket" {
   }
 }
 
+resource "aws_s3_bucket_ownership_controls" "agentless_scan_bucket_ownership_controls" {
+  bucket = aws_s3_bucket.agentless_scan_bucket[0].id
+
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
+
 resource "aws_s3_bucket_public_access_block" "agentless_scan_bucket_public_access_block" {
   count  = var.global ? 1 : 0
   bucket = aws_s3_bucket.agentless_scan_bucket[0].id

--- a/main.tf
+++ b/main.tf
@@ -532,6 +532,7 @@ resource "aws_s3_bucket" "agentless_scan_bucket" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "agentless_scan_bucket_ownership_controls" {
+  count  = var.global ? 1 : 0
   bucket = aws_s3_bucket.agentless_scan_bucket[0].id
 
   rule {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary
To enable bucket ACL the ObjectOwnership parameter must be set to ObjectWriter.

https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html
https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
ran terraform plan

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue
https://lacework.atlassian.net/browse/GROW-1534
<!--
  Include the link to a Jira/Github issue
-->