### PR TITLE
fix: Removed check for suffix having more than 4 chars, because it doesn't…

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -261,8 +261,8 @@ variable "suffix" {
   default     = ""
 
   validation {
-    condition     = length(var.suffix) == 0 || length(var.suffix) > 4
-    error_message = "If the suffix value is set then it must be at least 4 characters long."
+    condition     = var.suffix != null
+    error_message = "The suffix must not be null. It can either be empty which is the default and means that the module will generate a random suffix or you can set one yourself."
   }
 }
 


### PR DESCRIPTION
… prevent redeployments with same name which closes #71

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
As we discussed in #71 I don't see any necessity for checking that the suffix has to have 4 chars. Prevention of naming conflicts is given by not setting the suffix, because the module will then generate a random one. But if I set the suffix myself, making it at least 4 chars long doesn't prevent any naming conflicts. If there is no other requirement for the length restriction, it seems obsolete to me.

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

I redirected the module reference from the release version to my local fork.

Case 1: No suffix set (using default value), plan was successful
Case 2: Set suffix to `"abc"` (value <4), plan was successful
Case 3: Set suffix `null`, plan threw the error as expected

## Issue

<!--
  Include the link to a Jira/Github issue
-->
#71