### PR TITLE
chore: Updated provider constraint to allow aws provider 5.x

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15.0"
 
   required_providers {
-    aws    = "~> 4.0"
+    aws    = ">= 4.0.0, < 6.0.0"
     random = ">= 2.1"
     lacework = {
       source  = "lacework/lacework"


### PR DESCRIPTION
This change allows not only the usage of aws provider version 4.x, but also the usage of 5.x.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

We are not able to update to aws provider 5.x, because of the version constraint in this module. Trying to update the aws provider version in the root module will result in the following error:

> │ Error: Failed to query available provider packages
│
│ Could not retrieve the list of available versions for provider hashicorp/aws: no available releases match the given constraints ~> 4.0, 5.0.1

From my perspective the change makes a lot more sense setting the minimum major version which is the version supported in the most recent release and the max version as the current aws major version. The intention is to only adjust the upper boundary after testing compatibility. Using `~>` makes more sense in a root module from my perspective. The root module can change the version, but passes down its provider to the submodule. So I suggest that the submodule should only have a constraint about its minimum and/or maximum version if necessary.

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

I picked root modules using _[terraform-aws-agentless-scanning](https://github.com/lacework/terraform-aws-agentless-scanning)_ which have been deployed already.
01 lacework-aws-agentless-scanning-global
02 lacework-aws-agentless-scanning-regional
03 lacework-aws-agentless-scanning-monitored-account

For each root module I ran the following test cases:

**Case 1:** 
aws provider version root module: `4.67.0`
lacework-aws-agentless-scanning module version: `0.10.0`
- Changed version constraint in `.terraform/modules/terraform-aws-agentless-scanning/versions.tf` the value of this PR
- removed `.terraform.lock.hcl`
- Run plan
- Result: ✅ successful

**Case 2:** 
- Changed root module version from `4.67.0` to `5.0.1`
- Version constraint in `.terraform/modules/terraform-aws-agentless-scanning/versions.tf` still having the value of this PR
- removed `.terraform.lock.hcl`
- Run plan
- Result: ✅ successful

## Issue

<!--
  Include the link to a Jira/Github issue
-->