### PR TITLE
Add account mapping variables for org integrations

### DIFF
--- a/examples/multi-account-lw-org/README.md
+++ b/examples/multi-account-lw-org/README.md
@@ -1,0 +1,151 @@
+# AWS Organizations integration Example
+
+## NOTE: This deployment type is currently in beta.
+
+In this example we add Terraform modules to three AWS accounts.
+
+- Scanning account, or Security account, where the scanning infrasturcture is installed.
+- Monitored account where a role used to create snapshots, and access snapshot data, is installed.
+- The AWS Organizations Management account so that accounts and OUs can be enumerated for each scan.
+
+For the Scanning Account the same process is followed compared to the Single Account Multi-Region example.
+However, this Scanning Account must know the AWS Organizations management account and set of OUs that will be scanned.
+
+For all accounts that will be the target of scanning, the role installed must be known (by name)
+to the Scanning Account. This example demonstrates how to do this properly.
+
+## How does this differ from a regular multi-account deployment?
+
+This type of deployment is specifically for environments that are a Lacework Organization and want to have specific aws account data flow into specific sub-lacework accounts. This requires the following:
+- The person performing the install must be an OrgAdmin for the Lacework account
+- Under provider "lacework" the parameter `organization = true` must be set
+- An account mapping must be provided in exactly the same type of setup as shown below. Note: multiple aws_accounts can be specified in the list for each sub-account. However, each aws account can only be specified once.
+
+## Sample Code
+
+### scanning_account.tf
+
+```hcl
+provider "lacework" {
+    organization = true
+}
+
+provider "aws" {
+  profile = "scanning-account"
+  alias   = "scanning-account-usw1"
+  region  = "us-west-1"
+}
+
+provider "aws" {
+  profile = "scanning-account"
+  alias   = "scanning-account-usw2"
+  region  = "us-west-2"
+}
+
+// Create global resources, includes lacework cloud integration
+module "lacework_aws_agentless_scanning_global" {
+  source  = "lacework/agentless-scanning/aws"
+  version = "~> 0.5"
+
+  providers = {
+    aws = aws.scanning-account-usw1
+  }
+
+  global       = true
+  organization = {
+    // This list may contain account IDs, OUs, or the organization root.
+    monitored_accounts = ["1234567890", "ou-abcd-12345678", "r-abcd"]
+    // This account ID must be the AWS organizations "management account".
+    // This wil be used to enumerate the accounts and OUs in the list of monitored accounts.
+    // This account must also have the snapshot_role installed.
+    management_account = "0001234567890"
+  }
+  org_account_mappings = [{
+    default_lacework_account = "main-account"
+    mapping = [
+      {
+        lacework_account = "sub-account-1"
+        aws_accounts     = ["123456789011"]
+      },
+      {
+        lacework_account = "sub-account-2"
+        aws_accounts     = ["123456789012"]
+      }
+    ]
+  }]
+
+  lacework_integration_name = "agentless_org_from_terraform"
+}
+
+// Create regional resources in our first region
+module "lacework_aws_agentless_scanning_region_usw1" {
+  source  = "lacework/agentless-scanning/aws"
+  version = "~> 0.5"
+
+  providers = {
+    aws = aws.scanning-account-usw1
+  }
+
+  regional                = true
+  global_module_reference = module.lacework_aws_agentless_scanning_global
+}
+
+// Create regional resources in our second region
+module "lacework_aws_agentless_scanning_region_usw2" {
+  source  = "lacework/agentless-scanning/aws"
+  version = "~> 0.5"
+
+  providers = {
+    aws = aws.scanning-account-usw2
+  }
+
+  regional                = true
+  global_module_reference = module.lacework_aws_agentless_scanning_global
+}
+```
+
+### monitored_account.tf
+
+```hcl
+provider "aws" {
+  profile = "monitored-account"
+  alias   = "monitored-account-usw1"
+  region  = "us-west-1"
+}
+
+// Create the required role for the monitored account.
+module "lacework_aws_agentless_monitored_scanning_role" {
+  source  = "lacework/agentless-scanning/aws"
+  version = "~> 0.5"
+
+  providers = {
+    aws = aws.monitored-account-usw1
+  }
+
+  snapshot_role           = true
+  global_module_reference = module.lacework_aws_agentless_scanning_global
+}
+```
+
+### management_account.tf
+
+```hcl
+provider "aws" {
+  profile = "management-account"
+  alias   = "management-account-usw1"
+  region  = "us-west-1"
+}
+
+// Create the required role for the management account.
+module "lacework_aws_agentless_management_scanning_role" {
+  source  = "lacework/agentless-scanning/aws"
+  version = "~> 0.5"
+
+  providers = {
+    aws = aws.management-account-usw1
+  }
+
+  snapshot_role           = true
+  global_module_reference = module.lacework_aws_agentless_scanning_global
+}
+```

--- a/examples/multi-account-lw-org/management_account.tf
+++ b/examples/multi-account-lw-org/management_account.tf
@@ -1,0 +1,18 @@
+provider "aws" {
+  // Set this profile to the AWS Organizations management account profile.
+  // profile = "management-account"
+  alias   = "management-account-usw1"
+  region  = "us-west-1"
+}
+
+// Create the required role for the management account.
+module "lacework_aws_agentless_management_scanning_role" {
+  source = "../.."
+
+  providers = {
+    aws = aws.management-account-usw1
+  }
+
+  snapshot_role           = true
+  global_module_reference = module.lacework_aws_agentless_scanning_global
+}

--- a/examples/multi-account-lw-org/monitored_account.tf
+++ b/examples/multi-account-lw-org/monitored_account.tf
@@ -1,0 +1,18 @@
+provider "aws" {
+  // Set this profile to the AWS Account profile that will be scanned by the scanning account.
+  // profile = "monitored-account"
+  alias   = "monitored-account-usw1"
+  region  = "us-west-1"
+}
+
+// Create the required role for the monitored account.
+module "lacework_aws_agentless_monitored_scanning_role" {
+  source = "../.."
+
+  providers = {
+    aws = aws.monitored-account-usw1
+  }
+
+  snapshot_role           = true
+  global_module_reference = module.lacework_aws_agentless_scanning_global
+}

--- a/examples/multi-account-lw-org/scanning_account.tf
+++ b/examples/multi-account-lw-org/scanning_account.tf
@@ -1,4 +1,6 @@
-provider "lacework" {}
+provider "lacework" {
+    organization = true
+}
 
 provider "aws" {
   // Set this profile to the single AWS Account where the scanning infrastructure will be deployed.
@@ -31,6 +33,19 @@ module "lacework_aws_agentless_scanning_global" {
     // This account must also have the snapshot_role installed.
     management_account = "0001234567890"
   }
+  org_account_mappings = [{
+    default_lacework_account = "main-account"
+    mapping = [
+      {
+        lacework_account = "sub-account-1"
+        aws_accounts     = ["123456789011"]
+      },
+      {
+        lacework_account = "sub-account-2"
+        aws_accounts     = ["123456789012"]
+      }
+    ]
+  }]
   
   lacework_integration_name = "agentless_org_from_terraform"
 }

--- a/examples/multi-account-lw-org/versions.tf
+++ b/examples/multi-account-lw-org/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.15.0"
+
+  required_providers {
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 1.0"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -120,6 +120,20 @@ resource "lacework_integration_aws_org_agentless_scanning" "lacework_cloud_accou
   monitored_accounts        = var.organization.monitored_accounts
   management_account        = var.organization.management_account
   scanning_account          = data.aws_caller_identity.current.account_id
+  dynamic "org_account_mappings" {
+    for_each = var.org_account_mappings
+    content {
+      default_lacework_account = org_account_mappings.value["default_lacework_account"]
+
+      dynamic "mapping" {
+        for_each = org_account_mappings.value["mapping"]
+        content {
+          lacework_account = mapping.value["lacework_account"]
+          aws_accounts     = mapping.value["aws_accounts"]
+        }
+      }
+    }
+  }
   credentials {
     role_arn    = local.cross_account_role_arn
     external_id = local.external_id

--- a/variables.tf
+++ b/variables.tf
@@ -191,6 +191,18 @@ variable "subnet_id" {
   description = "The ID of the subnet to use for scanning compute resources.  Must also set `use_existing_subnet` to `true`."
 }
 
+variable "org_account_mappings" {
+  type = list(object({
+    default_lacework_account = string
+    mapping = list(object({
+      lacework_account = string
+      aws_accounts     = list(string)
+    }))
+  }))
+  default     = []
+  description = "Mapping of AWS accounts to Lacework accounts within a Lacework organization"
+}
+
 // The following inputs are use for organization (or multi-account) scanning.
 
 variable "organization" {


### PR DESCRIPTION
## Summary

This is the last change needed to enact LW Org Support for Agentless (for AWS). It adds an account mapping variable and sets it within the "lacework_integration_aws_org_agentless_scanning" resource. 

## How did you test this change?

Tested the following scenarios:
1) As an Org Admin, tested by deploying with an account mapping and `organization = true` parameter set in lacework provider options. **Outcome:** The deployment went through successfully, creating all resources & beginning a scan. The integration showed in the LW Org Account and the account mapping file was created / transformed from Terraform successfully.
<img width="484" alt="Screen Shot 2023-06-02 at 1 45 45 PM" src="https://github.com/lacework/terraform-aws-agentless-scanning/assets/107059599/3793c031-a935-479a-9054-eed5f4c4faee">
<img width="502" alt="Screen Shot 2023-06-02 at 1 45 53 PM" src="https://github.com/lacework/terraform-aws-agentless-scanning/assets/107059599/29b54206-1ccf-477a-a300-2241ada9c646">
<img width="430" alt="Screen Shot 2023-06-02 at 1 46 06 PM" src="https://github.com/lacework/terraform-aws-agentless-scanning/assets/107059599/eb5fbb07-6c6f-4838-9ecd-809d4de9837e">
<img width="1345" alt="Screen Shot 2023-06-02 at 1 46 12 PM" src="https://github.com/lacework/terraform-aws-agentless-scanning/assets/107059599/6507c3d2-f506-45db-9285-7f50ca675317">
<img width="618" alt="Screen Shot 2023-06-02 at 1 48 31 PM" src="https://github.com/lacework/terraform-aws-agentless-scanning/assets/107059599/4102e4fa-c5b2-400e-9d54-b686ac43ad14">
<img width="421" alt="Screen Shot 2023-06-02 at 1 48 39 PM" src="https://github.com/lacework/terraform-aws-agentless-scanning/assets/107059599/710c25ec-3ecf-4480-9f83-4d9c276a81d9">
<img width="525" alt="Screen Shot 2023-06-02 at 1 50 09 PM" src="https://github.com/lacework/terraform-aws-agentless-scanning/assets/107059599/79cd650a-be23-4fa0-8307-9e53ab8860d5">


2) As an Org Admin, tested without an account mapping, expecting an error for the outcome and the integration to NOT be created successfully. When deploying an org integration from the LW Org Account, an account mapping is required. **Outcome: Error produced that was expecting asking the customer to provide an account mapping** 
<img width="611" alt="Screen Shot 2023-06-02 at 2 14 07 PM" src="https://github.com/lacework/terraform-aws-agentless-scanning/assets/107059599/208e99d8-89a0-4451-97de-0310f80441c1">
<img width="931" alt="Screen Shot 2023-06-02 at 2 15 24 PM" src="https://github.com/lacework/terraform-aws-agentless-scanning/assets/107059599/d283c9f8-0f2f-401d-a86a-8389876146cd">

3) As a regular user aka `organization != true`, with & without an account mapping. Expectation is that a regular user with an account mapping should not be able to create an org integration. Without an account mapping, they should be able to create an org integration (but it will not be from the LW org level and will not contain an account mapping). This is for a use case where customers have a couple of accounts within an org, but may not want to take advantage of the account mapping option and have all results go to the same LW account. **Outcome without account mapping:** Successfully deployed, integration showing in UI & all resources created. 
<img width="1164" alt="Screen Shot 2023-06-02 at 2 31 31 PM" src="https://github.com/lacework/terraform-aws-agentless-scanning/assets/107059599/e3d7b31e-868d-4d5a-98b3-53284179d4e9">
<img width="737" alt="Screen Shot 2023-06-02 at 2 31 40 PM" src="https://github.com/lacework/terraform-aws-agentless-scanning/assets/107059599/e1cb22ea-a70e-4943-9078-e9561bf00f0b">

**Outcome with account mapping and organization != true (expecting error):**
<img width="923" alt="Screen Shot 2023-06-02 at 2 49 55 PM" src="https://github.com/lacework/terraform-aws-agentless-scanning/assets/107059599/a517c7dd-57e7-41c8-8b55-b7845f3ef8d9">


## Issue
https://lacework.atlassian.net/browse/RAIN-54797