### PR TITLE
fix: bump lacework provider min version to '~> 1.8'

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     random = ">= 2.1"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 1.0"
+      version = "~> 1.8"
     }
   }
 }


### PR DESCRIPTION
## Summary

The PR https://github.com/lacework/terraform-provider-lacework/pull/473 introduced a new field named `org_account_mappings` which is only available from version `1.8.0` and above.

We made use of this new variable with PR https://github.com/lacework/terraform-aws-agentless-scanning/pull/81 but we forgot to bump the min version, this causes potential issues like https://github.com/lacework/terraform-aws-agentless-scanning/issues/83 where users might be using an older version of the Lacework provider that does not have this new field.

The fix is to update the version constraint to `~> 1.8`

Note: If you don't know about the pessimistic constraint, please read this doc; https://developer.hashicorp.com/terraform/language/expressions/version-constraints#version-constraint-syntax


## How did you test this change?

Ran terraform locally and CI should pass.

## Issue

Closes https://github.com/lacework/terraform-aws-agentless-scanning/issues/83
