### PR TITLE
refactor: Changed the eventbridge rule to use the scan interval as tr…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -980,7 +980,7 @@ resource "aws_cloudwatch_event_rule" "agentless_scan_event_rule" {
 
   count               = var.regional ? 1 : 0
   name                = "${local.prefix}-periodic-trigger-${local.suffix}"
-  schedule_expression = "rate(1 hour)"
+  schedule_expression = "rate(${var.scan_frequency_hours} hour)"
   event_bus_name      = "default"
 }
 


### PR DESCRIPTION
…igger.

Currently the sidekick container runs every hour. Even if you set the scan interval to 24 hours. This change uses the value from the scan interval for the scheduled trigger in EventBridge.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

When the config of the scan interval is set to 24 hours the sidekick container produces a lot of unnecessary noise in Cloudwatch. Why not set the trigger in hours to the same interval as the scan interval?

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->