### PR TITLE
fix: remove ingress rule allowing traffic within security group for agentless integrations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -864,12 +864,7 @@ resource "aws_security_group" "agentless_scan_sec_group" {
   description = "A security group to allow Lacework Agentless Workload Scanning communication."
   vpc_id      = local.vpc_id
 
-  ingress {
-    protocol  = -1
-    self      = true
-    from_port = 0
-    to_port   = 0
-  }
+  ingress = []
 
   egress {
     from_port   = 443


### PR DESCRIPTION
## Summary

This fixes https://lacework.atlassian.net/browse/RAIN-64969. The security group ingress rule created as part of agentless integrations was triggering Lacework policies in customer environments.

The rule itself is not insecure -- it only allows traffic from within the security group, not the wider internet -- there is no longer any reason to have an ingress rule in the first place. This PR removes it entirely. 

## How did you test this change?

I made this change in a local version of our Terraform provider and created a new agentless integration with it, confirming that scans still run and succeed as expected. See results here: https://ui.honeycomb.io/lacework/datasets/agentless-sidekick-prod/result/vfV3do9kiJP/trace/j1KAiWymLrX

## Issue
https://lacework.atlassian.net/browse/RAIN-64969