### PR TITLE
feat(RAIN-54831): Add multi volume & scan stopped instances variable fields

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -100,6 +100,7 @@ resource "lacework_integration_aws_agentless_scanning" "lacework_cloud_account" 
   scan_containers           = var.scan_containers
   scan_host_vulnerabilities = var.scan_host_vulnerabilities
   scan_multi_volume         = var.scan_multi_volume
+  scan_stopped_instances    = var.scan_stopped_instances
   account_id                = data.aws_caller_identity.current.account_id
   bucket_arn                = aws_s3_bucket.agentless_scan_bucket[0].arn
   credentials {
@@ -116,6 +117,7 @@ resource "lacework_integration_aws_org_agentless_scanning" "lacework_cloud_accou
   query_text                = var.filter_query_text
   scan_containers           = var.scan_containers
   scan_host_vulnerabilities = var.scan_host_vulnerabilities
+  scan_stopped_instances    = var.scan_stopped_instances
   scan_multi_volume         = var.scan_multi_volume
   account_id                = data.aws_caller_identity.current.account_id
   bucket_arn                = aws_s3_bucket.agentless_scan_bucket[0].arn

--- a/main.tf
+++ b/main.tf
@@ -99,6 +99,7 @@ resource "lacework_integration_aws_agentless_scanning" "lacework_cloud_account" 
   query_text                = var.filter_query_text
   scan_containers           = var.scan_containers
   scan_host_vulnerabilities = var.scan_host_vulnerabilities
+  scan_multi_volume         = var.scan_multi_volume
   account_id                = data.aws_caller_identity.current.account_id
   bucket_arn                = aws_s3_bucket.agentless_scan_bucket[0].arn
   credentials {
@@ -115,6 +116,7 @@ resource "lacework_integration_aws_org_agentless_scanning" "lacework_cloud_accou
   query_text                = var.filter_query_text
   scan_containers           = var.scan_containers
   scan_host_vulnerabilities = var.scan_host_vulnerabilities
+  scan_multi_volume         = var.scan_multi_volume
   account_id                = data.aws_caller_identity.current.account_id
   bucket_arn                = aws_s3_bucket.agentless_scan_bucket[0].arn
   monitored_accounts        = var.organization.monitored_accounts

--- a/variables.tf
+++ b/variables.tf
@@ -90,6 +90,12 @@ variable "scan_host_vulnerabilities" {
   default     = true
 }
 
+variable "scan_multi_volume" {
+  type = bool
+  description = "Whether to scan secondary volumes. Defaults to `false`."
+  default = false
+}
+
 variable "bucket_force_destroy" {
   type        = bool
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -96,6 +96,12 @@ variable "scan_multi_volume" {
   default = false
 }
 
+variable "scan_stopped_instances" {
+  type = bool
+  description = "Whether to scan stopped instances. Defaults to `true`."
+  default = true
+}
+
 variable "bucket_force_destroy" {
   type        = bool
   default     = true


### PR DESCRIPTION
# Summary
This is part of the work of multi-volume (secondary volume) and stopped instances scanning features for agentless workload scanning. We are finishing up the feature by adding a toggle / boolean for integrations to indicate if they want to turn on Multi-Volume scanning and/or Stopped Instances scanning. This is handled on the backend (in sidekick) to "turn on" the feature if the boolean is set to true.

Last part of: https://github.com/lacework/go-sdk/pull/1275, https://github.com/lacework/terraform-provider-lacework/pull/484

# How did you test this change?
I tested this by running terraform against this commit and added the scan_multi_volume and scan_stopped_instances (set to true and false respectively). Terraform was successfully deployed and shows correct booleans in the UI.

Issue
https://lacework.atlassian.net/browse/RAIN-54831