### PR TITLE
fix: add condition to kms to only operate on aws resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -93,6 +93,7 @@ resource "lacework_external_id" "aws_iam_external_id" {
 }
 
 resource "lacework_integration_aws_agentless_scanning" "lacework_cloud_account" {
+  // TODO: add depends on
   count                     = var.global && !local.is_org_integration ? 1 : 0
   name                      = var.lacework_integration_name
   scan_frequency            = var.scan_frequency_hours
@@ -111,6 +112,7 @@ resource "lacework_integration_aws_agentless_scanning" "lacework_cloud_account" 
 
 resource "lacework_integration_aws_org_agentless_scanning" "lacework_cloud_account" {
   // If var.organization is used then also add monitored accounts and scanning account as the caller.
+  // TODO: add depends on
   count                     = var.global && local.is_org_integration ? 1 : 0
   name                      = var.lacework_integration_name
   scan_frequency            = var.scan_frequency_hours
@@ -305,6 +307,13 @@ data "aws_iam_policy_document" "agentless_scan_task_policy_document" {
       variable = "kms:ViaService"
       values   = ["ec2.*.amazonaws.com"]
     }
+  
+    condition {
+      test = "Bool"
+      variable = "kms:GrantIsForAWSResource"
+      values = [true]
+    }
+
   }
 
   statement {

--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,6 @@ resource "lacework_external_id" "aws_iam_external_id" {
 }
 
 resource "lacework_integration_aws_agentless_scanning" "lacework_cloud_account" {
-  // TODO: add depends on
   count                     = var.global && !local.is_org_integration ? 1 : 0
   name                      = var.lacework_integration_name
   scan_frequency            = var.scan_frequency_hours
@@ -112,7 +111,6 @@ resource "lacework_integration_aws_agentless_scanning" "lacework_cloud_account" 
 
 resource "lacework_integration_aws_org_agentless_scanning" "lacework_cloud_account" {
   // If var.organization is used then also add monitored accounts and scanning account as the caller.
-  // TODO: add depends on
   count                     = var.global && local.is_org_integration ? 1 : 0
   name                      = var.lacework_integration_name
   scan_frequency            = var.scan_frequency_hours


### PR DESCRIPTION
## Summary

This fixes https://lacework.atlassian.net/browse/LINK-1998. This changes our terraform to follow best practices and further scope down the permission KmsGrant to only allow use on AWS resources.

## How did you test this change?

I made this change in a local version of our Terraform provider and created a new agentless integration with it, confirming that scans still run and succeed as expected. https://ui.honeycomb.io/lacework/datasets/agentless-sidekick-prod/result/vxN2xQHKX6j

## Issue

https://lacework.atlassian.net/browse/LINK-1998