### PR TITLE
Update NACL rules

### DIFF
--- a/examples/single-account-single-region/main.tf
+++ b/examples/single-account-single-region/main.tf
@@ -1,7 +1,7 @@
 provider "lacework" {}
 
 provider "aws" {
-  region = "us-west-1"
+  region = "us-west-2"
 }
 
 // Create global resources, includes lacework cloud integration.

--- a/examples/single-account-single-region/main.tf
+++ b/examples/single-account-single-region/main.tf
@@ -1,7 +1,7 @@
 provider "lacework" {}
 
 provider "aws" {
-  region = "us-west-2"
+  region = "us-west-1"
 }
 
 // Create global resources, includes lacework cloud integration.

--- a/main.tf
+++ b/main.tf
@@ -835,15 +835,6 @@ resource "aws_default_network_acl" "default" {
 
   ingress {
     protocol   = 6
-    rule_no    = 100
-    action     = "allow"
-    cidr_block = "0.0.0.0/0"
-    from_port  = 443
-    to_port    = 443
-  }
-
-  ingress {
-    protocol   = 6
     rule_no    = 101
     action     = "allow"
     cidr_block = "0.0.0.0/0"

--- a/main.tf
+++ b/main.tf
@@ -821,6 +821,7 @@ resource "aws_vpc" "agentless_scan_vpc" {
 }
 
 resource "aws_default_network_acl" "default" {
+  count = var.regional && !var.use_existing_vpc ? 1 : 0
   default_network_acl_id = aws_vpc.agentless_scan_vpc[0].default_network_acl_id
 
   egress {

--- a/main.tf
+++ b/main.tf
@@ -820,6 +820,38 @@ resource "aws_vpc" "agentless_scan_vpc" {
   }
 }
 
+resource "aws_default_network_acl" "default" {
+  default_network_acl_id = aws_vpc.agentless_scan_vpc[0].default_network_acl_id
+
+  egress {
+    protocol   = -1
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  ingress {
+    protocol   = 6
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 443
+    to_port    = 443
+  }
+
+  ingress {
+    protocol   = 6
+    rule_no    = 101
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 1024
+    to_port    = 65535
+  }
+
+}
+
 resource "aws_route_table" "agentless_scan_route_table" {
   count  = var.regional && !var.use_existing_subnet ? 1 : 0
   vpc_id = local.vpc_id


### PR DESCRIPTION
Summary
This fixes https://lacework.atlassian.net/browse/LINK-2014. This changes our terraform to scope down the ingress and egress rules allowed by the subnet NACL.

How did you test this change?
I made this change in a local version of our Terraform provider and created a new agentless integration with it, confirming that scans still run and succeed as expected.

Issue
https://lacework.atlassian.net/browse/LINK-2014