### PR TITLE
fix: Update default nacl

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -820,6 +820,29 @@ resource "aws_vpc" "agentless_scan_vpc" {
   }
 }
 
+resource "aws_default_network_acl" "default" {
+  count = var.regional && !var.use_existing_vpc ? 1 : 0
+  default_network_acl_id = aws_vpc.agentless_scan_vpc[0].default_network_acl_id
+
+  egress {
+    protocol   = -1
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  ingress {
+    protocol   = 6
+    rule_no    = 101
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 1024
+    to_port    = 65535
+  }
+}
+
 resource "aws_route_table" "agentless_scan_route_table" {
   count  = var.regional && !var.use_existing_subnet ? 1 : 0
   vpc_id = local.vpc_id


### PR DESCRIPTION
## Summary
This fixes https://lacework.atlassian.net/browse/LINK-2014. This changes our terraform to scope down the ingress and egress rules allowed by the subnet NACL.

## How did you test this change?
I made this change in a local version of our Terraform provider and created a new agentless integration with it, confirming that scans still run and succeed as expected.

## Issue
https://lacework.atlassian.net/browse/LINK-2014