### PR TITLE
fix: add condition to kms to only operate on aws resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -305,6 +305,12 @@ data "aws_iam_policy_document" "agentless_scan_task_policy_document" {
       variable = "kms:ViaService"
       values   = ["ec2.*.amazonaws.com"]
     }
+
+    condition {
+      test = "Bool"
+      variable = "kms:GrantIsForAWSResource"
+      values = [true]
+    }
   }
 
   statement {


### PR DESCRIPTION
## Summary
This fixes https://lacework.atlassian.net/browse/LINK-1998. This changes our terraform to follow best practices and further scope down the permission KmsGrant to only allow use on AWS resources.

Issue
https://lacework.atlassian.net/browse/LINK-1998

## How did you test this change?

How did you test this change?
I made this change in a local version of our Terraform provider and created a new agentless integration with it, confirming that scans still run and succeed as expected. https://ui.honeycomb.io/lacework/datasets/agentless-sidekick-prod/result/vxN2xQHKX6j

## Issue

https://lacework.atlassian.net/browse/LINK-1998