### PR TITLE
fix: Scope down create tag permissions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -244,10 +244,23 @@ data "aws_iam_policy_document" "agentless_scan_task_policy_document" {
     sid    = "CreateSnapshots"
     effect = "Allow"
     actions = [
-      "ec2:CreateTags",
       "ec2:CreateSnapshot"
     ]
     resources = ["*"]
+  }
+
+  statement {
+    sid    = "CreateSnapshotTags"
+    effect = "Allow"
+    actions = [
+      "ec2:CreateTags"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:CreateAction"
+      values   = ["CreateSnapshot"]
+    }
   }
 
   statement {
@@ -496,9 +509,22 @@ resource "aws_iam_role" "agentless_scan_snapshot_role" {
         },
         {
           Sid      = "CreateSnapshots"
-          Action   = ["ec2:CreateTags", "ec2:CreateSnapshot"]
+          Action   = ["ec2:CreateSnapshot"]
           Effect   = "Allow"
           Resource = "*"
+        },
+        {
+          Sid    = "CreateSnapshotTags"
+          Effect = "Allow"
+          Action = [
+            "ec2:CreateTags"
+          ]
+          Resource = ["*"]
+          Condition = {
+            StringEquals = {
+              "ec2:CreateAction" = "CreateSnapshot"
+            }
+          }
         },
         {
           Sid = "SnapshotManagement"


### PR DESCRIPTION
## Summary

This fixes https://lacework.atlassian.net/browse/RAIN-75027. This changes our terraform to follow best practices and further scope down the permission KmsGrant to only allow use on AWS resources.

Issue
https://lacework.atlassian.net/browse/RAIN-75027

## How did you test this change?

How did you test this change?
I made this change in a local version of our Terraform provider and created a new agentless integration with it, confirming that scans still run and succeed as expected. 

## Issue
https://lacework.atlassian.net/browse/RAIN-75027