### PR TITLE
fix: Limit kms:GrantIsForAWSResource condition key to kms:CreateGrant

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -296,7 +296,20 @@ data "aws_iam_policy_document" "agentless_scan_task_policy_document" {
       "kms:Encrypt",
       "kms:Decrypt",
       "kms:ReEncrypt*",
-      "kms:GenerateDataKey*",
+      "kms:GenerateDataKey*"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringLike"
+      variable = "kms:ViaService"
+      values   = ["ec2.*.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid    = "SnapshotEncryptionGrants"
+    effect = "Allow"
+    actions = [
       "kms:CreateGrant"
     ]
     resources = ["*"]
@@ -514,13 +527,28 @@ resource "aws_iam_role" "agentless_scan_snapshot_role" {
             "kms:Encrypt",
             "kms:Decrypt",
             "kms:ReEncrypt*",
-            "kms:GenerateDataKey*",
+            "kms:GenerateDataKey*"
+          ]
+          Resource = "*"
+          Condition = {
+            StringLike = {
+              "kms:ViaService" = "ec2.*.amazonaws.com"
+            }
+          }
+        },
+        {
+          Sid    = "SnapshotEncryptionGrants"
+          Effect = "Allow"
+          Action = [
             "kms:CreateGrant"
           ]
           Resource = "*"
           Condition = {
             StringLike = {
               "kms:ViaService" = "ec2.*.amazonaws.com"
+            }
+            Bool = {
+              "kms:GrantIsForAWSResource" = "true"
             }
           }
         },


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

The `kms:GrantIsForAWSResource` condition key only applies to `CreateGrant`, `RevokeGrant`, and `ListGrants`: https://docs.aws.amazon.com/kms/latest/developerguide/conditions-kms.html#conditions-kms-grant-is-for-aws-resource

Having it apply to other APIs will cause them to fail.

## How did you test this change?

Deploy with `source = <commit_id>` using the module/documentation. And test with:
- Customer-managed KMS key
- AWS-managed KMS key

## Issue

N/A