### PR TITLE
fix: `count` from lacework_external_id resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -87,7 +87,7 @@ resource "random_id" "uniq" {
 // count = var.global ? 1 : 0
 
 resource "lacework_external_id" "aws_iam_external_id" {
-  count      = length(var.external_id) > 0 ? 0 : 1
+  count      = var.use_existing_cross_account_role ? 0 : 1
   csp        = "aws"
   account_id = data.aws_caller_identity.current.account_id
 }


### PR DESCRIPTION
## Summary

If a user is chaining modules to create a single IAM role and passing the external id from the IAM Role module, Terraform will error with:
```
The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created.
```

Example Gist of how to chain ALL our AWS modules to deploy Lacework.

https://gist.github.com/afiune/08a4ef4547dab13ce2c1367a122543a6

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->



<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Used the Gist to deploy all integrations into a single AWS account

## Issue

<!--
  Include the link to a Jira/Github issue
-->
https://lacework.atlassian.net/browse/GROW-2468