### PR TITLE
fix: bump lacework provider min version to '~> 1.15'

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
-| <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 1.8 |
+| <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 1.15 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.1 |
 
 ## Providers
@@ -22,7 +22,7 @@ A Terraform Module to configure the Lacework Agentless Scanner.
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
-| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 1.8 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 1.15 |
 | <a name="provider_null"></a> [null](#provider\_null) | n/a |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.1 |
 

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     random = ">= 2.1"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 1.8"
+      version = "~> 1.15"
     }
   }
 }


### PR DESCRIPTION

## Summary

The PR https://github.com/lacework/terraform-aws-agentless-scanning/pull/97 used a new resource `lacework_external_id ` which is only available from version `1.15.0` and above but we forgot to bump the min version, this causes issues like https://github.com/lacework/terraform-aws-agentless-scanning/issues/107 where users might be using an older version of the Lacework provider that does not have this new resource.

The fix is to update the version constraint to `~> 1.15`

Note: If you don't know about the pessimistic constraint, please read this doc:

https://developer.hashicorp.com/terraform/language/expressions/version-constraints#version-constraint-syntax

## Issue

Closes https://github.com/lacework/terraform-aws-agentless-scanning/issues/107