### PR TITLE
fix: Skip port 3389

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -872,6 +872,15 @@ resource "aws_default_network_acl" "default" {
     action     = "allow"
     cidr_block = "0.0.0.0/0"
     from_port  = 1024
+    to_port    = 3388
+  }
+  
+  ingress {
+    protocol   = 6
+    rule_no    = 102
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 3390
     to_port    = 65535
   }
 }


### PR DESCRIPTION
## Summary
This fixes https://lacework.atlassian.net/browse/LINK-2014. This changes our terraform to scope down the ingress and egress rules allowed by the subnet NACL.

## How did you test this change?

I made this change in a local version of our Terraform provider and created a new agentless integration with it, confirming that scans still run and succeed as expected.

## Issue

https://lacework.atlassian.net/browse/LINK-2014