### PR TITLE
[repeat #118]Pass in KMS key for Cloud Watch

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1061,6 +1061,9 @@ resource "aws_cloudwatch_log_group" "agentless_scan_log_group" {
   count             = var.regional ? 1 : 0
   name              = "/ecs/${aws_ecs_cluster.agentless_scan_ecs_cluster[0].name}"
   retention_in_days = 14
+  # the KMS will need to allow the log group to use it.
+  # See https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html
+  kms_key_id        = var.secretsmanager_kms_key_id
 }
 
 resource "aws_cloudwatch_event_rule" "agentless_scan_event_rule" {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

(note this is a redo of https://github.com/lacework/terraform-aws-agentless-scanning/pull/118 because I couldn't seem to sign the previous PR)

Pass in the key secret manager KMS key ARN id to be used for cloudwatch log group encryption.


## How did you test this change?

Testing on Agentless tier

* Created a KMS
* Modified https://github.com/lacework/terraform-aws-agentless-scanning/tree/main/examples/single-account-single-region to create a testing deployment
* Edited the KMS access policy so it could be used for the newly created log group
* Re-ran the above deployment with my change, observe that KMS has been enabled :

## Issue

https://lacework.atlassian.net/browse/LINK-2235