### PR TITLE
refactor(role): update to use Lacework external IAM role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -754,7 +754,7 @@ data "aws_iam_policy_document" "agentless_scan_cross_account_policy" {
     actions = ["sts:AssumeRole"]
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.lacework_aws_account_id}:root"]
+      identifiers = ["arn:aws:iam::${var.lacework_aws_account_id}:role/lacework-platform"]
     }
     condition {
       test     = "StringEquals"


### PR DESCRIPTION
## Summary

Switching to an external IAM role allows us to adhere to least privileges principles, which we previously were not. 

## How did you test this change?

I actually have to merge to main before testing it

## Issue

https://lacework.atlassian.net/browse/GROW-2447
