### PR TITLE
fix: tighten up the passrole permission a bit

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -352,6 +352,11 @@ data "aws_iam_policy_document" "agentless_scan_task_policy_document" {
       variable = "iam:ResourceTag/LWTAG_SIDEKICK"
       values   = ["*"]
     }
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["ecs-tasks.amazonaws.com"]
+    }
   }
 
   statement {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary
Tighten up the perm of `iam:PassRole` slightly. `iam:PassedToService` allows one to restrict what services the role is passed to. In our case, it's ECS.

There's potential to use `resources` to tighten up things a bit further. Checking the "Access Advisor" of the IAM role, I noticed that the role uses 
* STS
* Secret Manager
* KMS
* EC2
* ECS
* S3
and decided not to replace the `["*"]` constraint we currently because I think making it more restrictive there may not help too much and runs the risk of breaking stuff. 

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

deploy to AWS and test out.

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->

https://lacework.atlassian.net/browse/RAIN-91410