### PR TITLE
NOT COMMIT: sample code for read-only root fs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1023,7 +1023,10 @@ resource "aws_ecs_task_definition" "agentless_scan_task_definition" {
     LWTAG_SIDEKICK           = "1"
     LWTAG_LACEWORK_AGENTLESS = "1"
   }
-
+  volume {
+    name = "tmp"
+    host_path = "/ecs/tmp"
+  }
   container_definitions = jsonencode([
     {
       name      = "sidekick"
@@ -1053,6 +1056,12 @@ resource "aws_ecs_task_definition" "agentless_scan_task_definition" {
           awslogs-stream-prefix = "ecs"
         }
       }
+      readonlyRootFilesystem = true
+      mountPoints = [{
+        sourceVolume  = "tmp"
+        containerPath = "/tmp"
+        readOnly      = false
+      }]
     }
   ])
 }


### PR DESCRIPTION
This is just a code sample of something I tried but didn't work for future reference. 

"""
The readonly option will make /tmp un-writeable, which breaks our scanner because it needs to write temporary file. To get around it you'll need to mount a separate writable /tmp volume. However, AWS doesn't support mounting volume in Fargate, so we just can't enable the read-only access without rearchitecting our whole scanner.
"""