### PR TITLE
fix: Align task policy to CloudFormation and add AssumeScanRoles

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -349,8 +349,7 @@ data "aws_iam_policy_document" "agentless_scan_task_policy_document" {
     sid    = "PassRoleToTasks"
     effect = "Allow"
     actions = [
-      "iam:PassRole",
-      "sts:AssumeRole"
+      "iam:PassRole"
     ]
     resources = ["*"]
     condition {
@@ -362,6 +361,20 @@ data "aws_iam_policy_document" "agentless_scan_task_policy_document" {
       test     = "StringEquals"
       variable = "iam:PassedToService"
       values   = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid    = "AssumeScanRoles"
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringLike"
+      variable = "iam:ResourceTag/LWTAG_SIDEKICK"
+      values   = ["*"]
     }
   }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

This aligns the task policy to the policy we have in CloudFormation. It fixes a bug where `sts:AssumeRole`

## How did you test this change?

We are testing from this branch.

## Issue

N/A