### PR TITLE
fix: Add unused optional ECS task parameters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1057,6 +1057,8 @@ resource "aws_ecs_task_definition" "agentless_scan_task_definition" {
       name      = "sidekick"
       image     = var.image_url
       essential = true
+      cpu       = 4096
+      memory    = 8192
       environment = setunion(
         local.default_ecs_task_environment_variables,
         var.additional_environment_variables,
@@ -1069,7 +1071,8 @@ resource "aws_ecs_task_definition" "agentless_scan_task_definition" {
       )
       linuxParameters = {
         capabilities = {
-          Add = ["SYS_PTRACE"]
+          Add  = ["SYS_PTRACE"]
+          Drop = []
         }
       }
       logConfiguration = {
@@ -1081,6 +1084,11 @@ resource "aws_ecs_task_definition" "agentless_scan_task_definition" {
           awslogs-stream-prefix = "ecs"
         }
       }
+
+      mountPoints    = []
+      portMappings   = []
+      systemControls = []
+      volumesFrom    = []
     }
   ])
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

This updates the task definition in Terraform to match CloudFormation.

This sets optional fields to be empty values and sets the default CPU = 4 (4096 in [Fargate units](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-cpu)) and Memory = 8GB.

## How did you test this change?

```
terraform init # Use source = to this PR's ref
terraform plan
terraform apply
```

Then re-plan and assure no changes

```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

## Issue

N/A