### PR TITLE
feat: Add VPC flow logs for module-created VPCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ No modules.
 | [aws_ecs_cluster.agentless_scan_ecs_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
 | [aws_ecs_cluster_capacity_providers.agentless_scan_capacity_providers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster_capacity_providers) | resource |
 | [aws_ecs_task_definition.agentless_scan_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_flow_log.agentless_scan_vpc_flow_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) | resource |
 | [aws_iam_policy.agentless_scan_task_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.agentless_scan_cross_account_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.agentless_scan_ecs_event_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |

--- a/main.tf
+++ b/main.tf
@@ -904,6 +904,19 @@ resource "aws_vpc" "agentless_scan_vpc" {
   })
 }
 
+resource "aws_flow_log" "agentless_scan_vpc_flow_log" {
+  count           = var.regional && !var.use_existing_vpc ? 1 : 0
+  vpc_id          = local.vpc_id
+  traffic_type    = "REJECT"
+  log_destination = "cloud-watch-logs"
+
+  tags = merge(var.tags, {
+    Name                     = "${local.prefix}-vpc"
+    LWTAG_SIDEKICK           = "1"
+    LWTAG_LACEWORK_AGENTLESS = "1"
+  })
+}
+
 resource "aws_default_network_acl" "default" {
   count                  = var.regional && !var.use_existing_vpc ? 1 : 0
   default_network_acl_id = aws_vpc.agentless_scan_vpc[0].default_network_acl_id

--- a/main.tf
+++ b/main.tf
@@ -905,10 +905,9 @@ resource "aws_vpc" "agentless_scan_vpc" {
 }
 
 resource "aws_flow_log" "agentless_scan_vpc_flow_log" {
-  count           = var.regional && !var.use_existing_vpc ? 1 : 0
-  vpc_id          = local.vpc_id
-  traffic_type    = "REJECT"
-  log_destination = "cloud-watch-logs"
+  count        = var.regional && !var.use_existing_vpc ? 1 : 0
+  vpc_id       = local.vpc_id
+  traffic_type = "REJECT"
 
   tags = merge(var.tags, {
     Name                     = "${local.prefix}-vpc"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

This adds flow logs for traffic type = REJECT to adopt best practice recommendations. These logs are only added to VPCs that are created/managed by this module. If an existing VPC is used, then it is up to the code managing that VPC to set flow log configuration.

## How did you test this change?

Integration tests.

## Issue

https://github.com/lacework/terraform-aws-agentless-scanning/issues/86