### PR TITLE
feat: Use S3 bucket for flow logs destination

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -909,6 +909,10 @@ resource "aws_flow_log" "agentless_scan_vpc_flow_log" {
   vpc_id       = local.vpc_id
   traffic_type = "REJECT"
 
+  # Send logs to manged S3 bucket.
+  log_destination_type = "s3"
+  log_destination      = "arn:aws:s3:::${local.prefix}-bucket-${local.suffix}/sidekick/flow-logs/"
+
   tags = merge(var.tags, {
     Name                     = "${local.prefix}-vpc"
     LWTAG_SIDEKICK           = "1"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

This updates the VPC flow logs to point to the S3 bucket managed by agentless. This will apply the correct age-out policy for the logs.

## How did you test this change?

Create an instance of this module using Terraform and validate the flow log resource is created.

## Issue

N/A