### PR TITLE
chore(GROW-2972): add output for ECS cluster ARN

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_agentless_scan_ecs_cluster_arn"></a> [agentless\_scan\_ecs\_cluster\_arn](#output\_agentless\_scan\_ecs\_cluster\_arn) | Output ECS cluster ARN. Useful for managing ECS tasks via AWS CLI/SDK. |
 | <a name="output_agentless_scan_ecs_event_role_arn"></a> [agentless\_scan\_ecs\_event\_role\_arn](#output\_agentless\_scan\_ecs\_event\_role\_arn) | Output ECS event role ARN. |
 | <a name="output_agentless_scan_ecs_execution_role_arn"></a> [agentless\_scan\_ecs\_execution\_role\_arn](#output\_agentless\_scan\_ecs\_execution\_role\_arn) | Output ECS execution role ARN. |
 | <a name="output_agentless_scan_ecs_task_role_arn"></a> [agentless\_scan\_ecs\_task\_role\_arn](#output\_agentless\_scan\_ecs\_task\_role\_arn) | Output ECS task role ARN. |

--- a/output.tf
+++ b/output.tf
@@ -13,6 +13,11 @@ output "agentless_scan_ecs_event_role_arn" {
   description = "Output ECS event role ARN."
 }
 
+output "agentless_scan_ecs_cluster_arn" {
+  value       = var.regional ? aws_ecs_cluster.agentless_scan_ecs_cluster[0].arn : null
+  description = "Output ECS cluster ARN. Useful for managing ECS tasks via AWS CLI/SDK."
+}
+
 output "agentless_scan_secret_arn" {
   value       = local.agentless_scan_secret_arn
   description = "AWS SecretsManager Secret ARN for Lacework Account and Token."


### PR DESCRIPTION
## Summary

Add output for ECS cluster ARN, so it can be used for managing ECS tasks outside of Terraform, e.g. via AWS CLI/SDK. 

## How did you test this change?

<img width="774" alt="Screenshot 2024-12-12 at 12 15 43 PM" src="https://github.com/user-attachments/assets/41a4fd3d-c385-495c-8e0b-f3c00f8d9e65" />
