### PR TITLE
fix: Add variable to disable aws_vpc_flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ No modules.
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | The ID of the subnet to use for scanning compute resources.  Must also set `use_existing_subnet` to `true`. | `string` | `""` | no |
 | <a name="input_suffix"></a> [suffix](#input\_suffix) | A string to be appended to the end of the name of all new resources. | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map/dictionary of Tags to be assigned to created resources | `map(string)` | `{}` | no |
+| <a name="input_use_aws_flow_log"></a> [use\_aws\_flow\_log](#input\_use\_aws\_flow\_log) | Whether or not you want to create AWS flow logs for the VPC. | `bool` | `true` | no |
 | <a name="input_use_existing_cross_account_role"></a> [use\_existing\_cross\_account\_role](#input\_use\_existing\_cross\_account\_role) | Set this to true to use an existing IAM cross account role | `bool` | `false` | no |
 | <a name="input_use_existing_event_role"></a> [use\_existing\_event\_role](#input\_use\_existing\_event\_role) | Set this to true to use an existing IAM event role | `bool` | `false` | no |
 | <a name="input_use_existing_execution_role"></a> [use\_existing\_execution\_role](#input\_use\_existing\_execution\_role) | Set this to true to use an existing IAM execution role | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -906,7 +906,7 @@ resource "aws_vpc" "agentless_scan_vpc" {
 }
 
 resource "aws_flow_log" "agentless_scan_vpc_flow_log" {
-  count        = var.regional && !var.use_existing_vpc ? 1 : 0
+  count        = var.regional && var.use_aws_flow_log && !var.use_existing_vpc ? 1 : 0
   vpc_id       = local.vpc_id
   traffic_type = "REJECT"
 

--- a/variables.tf
+++ b/variables.tf
@@ -360,3 +360,9 @@ variable "use_internet_gateway" {
   default     = true
   description = "Whether or not you want to use an 'AWS internet gateway' for internet facing traffic. Only set this to false if you route internet traffic using a different approach."
 }
+
+variable "use_aws_flow_log" {
+  type = bool
+  default = true
+  description = "Whether or not you want to create AWS flow logs for the VPC."
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

https://lacework.atlassian.net/browse/GROW-3001

aws_flow_log was not created successful with multiple regions selected. 
Add variable to disable the creation of aws_flow_log 


## How did you test this change?

Tested `terraform apply` locally 

## Issue

<!--
  Include the link to a Jira/Github issue
-->