### PR TITLE
chore(AWLS2-550): update Terraform examples

### DIFF
--- a/examples/multi-account-lw-org/README.md
+++ b/examples/multi-account-lw-org/README.md
@@ -1,7 +1,5 @@
 # AWS Organizations integration Example
 
-## NOTE: This deployment type is currently in beta.
-
 In this example we add Terraform modules to three AWS accounts.
 
 - Scanning account, or Security account, where the scanning infrasturcture is installed.
@@ -22,6 +20,20 @@ This type of deployment is specifically for environments that are a Lacework Org
 - An account mapping must be provided in exactly the same type of setup as shown below. Note: multiple aws_accounts can be specified in the list for each sub-account. However, each aws account can only be specified once.
 
 ## Sample Code
+
+### versions.tf
+```hcl
+terraform {
+  required_version = ">= 0.15.0"
+
+  required_providers {
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 2.0"
+    }
+  }
+}
+```
 
 ### scanning_account.tf
 

--- a/examples/multi-account-multi-region-auto-snapshot/README.md
+++ b/examples/multi-account-multi-region-auto-snapshot/README.md
@@ -15,6 +15,20 @@ to the Scanning account. This example demonstrates how to do this properly.
 
 ## Sample Code
 
+### versions.tf
+```hcl
+terraform {
+  required_version = ">= 0.15.0"
+
+  required_providers {
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 2.0"
+    }
+  }
+}
+```
+
 ### scanning_account.tf
 
 ```hcl

--- a/examples/multi-account-multi-region/README.md
+++ b/examples/multi-account-multi-region/README.md
@@ -14,6 +14,20 @@ to the Scanning Account. This example demonstrates how to do this properly.
 
 ## Sample Code
 
+### versions.tf
+```hcl
+terraform {
+  required_version = ">= 0.15.0"
+
+  required_providers {
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 2.0"
+    }
+  }
+}
+```
+
 ### scanning_account.tf
 
 ```hcl

--- a/examples/single-account-existing-vpc-networking/README.md
+++ b/examples/single-account-existing-vpc-networking/README.md
@@ -1,5 +1,20 @@
 # Single Account with Existing VPC & Networking Example
 
+### versions.tf
+```hcl
+terraform {
+  required_version = ">= 0.15.0"
+
+  required_providers {
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 2.0"
+    }
+  }
+}
+```
+
+### main.tf
 ```hcl
 provider "lacework" {}
 

--- a/examples/single-account-multi-region/README.md
+++ b/examples/single-account-multi-region/README.md
@@ -1,5 +1,20 @@
 # Single Account with Multiple Regions Example
 
+### versions.tf
+```hcl
+terraform {
+  required_version = ">= 0.15.0"
+
+  required_providers {
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 2.0"
+    }
+  }
+}
+```
+
+### main.tf
 ```hcl
 
 provider "lacework" {}

--- a/examples/single-account-single-region/README.md
+++ b/examples/single-account-single-region/README.md
@@ -1,5 +1,20 @@
 # Single Account with Single Region Example
 
+### versions.tf
+```hcl
+terraform {
+  required_version = ">= 0.15.0"
+
+  required_providers {
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 2.0"
+    }
+  }
+}
+```
+
+### main.tf
 ```hcl
 
 provider "lacework" {}

--- a/examples/use-existing-iam-roles-multi-region/README.md
+++ b/examples/use-existing-iam-roles-multi-region/README.md
@@ -1,5 +1,20 @@
 # Use Existing IAM Roles Example
 
+### versions.tf
+```hcl
+terraform {
+  required_version = ">= 0.15.0"
+
+  required_providers {
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 2.0"
+    }
+  }
+}
+```
+
+### main.tf
 ```hcl
 
 provider "lacework" {}

--- a/examples/use-existing-iam-roles-single-region/README.md
+++ b/examples/use-existing-iam-roles-single-region/README.md
@@ -1,5 +1,20 @@
 # Use Existing IAM Roles Example
 
+### versions.tf
+```hcl
+terraform {
+  required_version = ">= 0.15.0"
+
+  required_providers {
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 2.0"
+    }
+  }
+}
+```
+
+### main.tf
 ```hcl
 
 provider "lacework" {}


### PR DESCRIPTION


## Summary
We are in the process of updating our public facing FortiCNAPP documentation to reference our Terraform examples directly (i.e. by linking to https://registry.terraform.io/modules/lacework/agentless-scanning/aws/latest) rather than replicating the Terraform in-line on the docs page.

The AWS examples in this repo are already and good shape and only one small change is needed for this transition: we need to add a sample `version.tf` to each example. That's all that this PR accomplishes.

## How did you test this change?

N/A. Docs only change.

## Issue
https://lacework.atlassian.net/browse/AWLS2-550